### PR TITLE
Import ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The standalone import/export utility can be run in either of two ways:
 The first time you run the utility with command-line arguments, a configuration file containing your provided arguments will be written to a file, the location of which will be displayed at the command line.
 
 ```sh
-$ java -jar fcrepo-import-export.jar --mode export --resource http://localhost:8080/rest --dir /tmp/test --binaries
+$ java -jar fcrepo-import-export.jar --mode export --resource http://localhost:8080/rest --dir /tmp/test --binaries --acls
 INFO 15:15:10.048 (ArgParser) Saved configuration to: /tmp/importexport.config
 INFO 15:15:10.091 (Exporter) Running exporter...
 ```
@@ -66,10 +66,10 @@ The list of RDF languages supported:
 - text/plain
 - text/turtle (or application/x-turtle)    (**default**)
 
-For example, to export all of the resources from a Fedora repository at `http://localhost:8080/rest/`, and put binaries and rdf in `/tmp/test`:
+For example, to export all the resources from a Fedora repository at `http://localhost:8080/rest/`, and put binaries and rdf in `/tmp/test`:
 
 ```sh
-java -jar fcrepo-import-export.jar --mode export --resource http://localhost:8080/rest/ --dir /tmp/test --binaries
+java -jar fcrepo-import-export.jar --mode export --resource http://localhost:8080/rest/ --dir /tmp/test --binaries --acls
 ```
 
 To then load that data into an empty Fedora repository at the same URL, run the same command, but using `--mode import` instead of `--mode export`.
@@ -262,7 +262,8 @@ That configuration file is [Yaml](http://yaml.org) and allows for the following 
 
 * mode: [import|export] # which mode to operate in
 * dir: Directory to import from/export to
-* binaries: [true|false] # whether is import/export binary resources
+* acls: [true|false] # whether to import/export acl resources
+* binaries: [true|false] # whether to import/export binary resources
 * overwriteTombstones: [true|false] # whether to replace tombstones of previously deleted resources
 * external: [true|false] # whether to retrieve external content binaries when exporting
 * inbound: [true|false] # whether to export inbound references when exporting

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -590,7 +590,7 @@ public class ArgParser {
                 c.setBagProfile(entry.getValue().toLowerCase());
             } else if (entry.getKey().equalsIgnoreCase(BAG_CONFIG_OPTION_KEY)) {
                 c.setBagConfigPath(entry.getValue().toLowerCase());
-            } else if (entry.getKey().trim().equalsIgnoreCase("algorithm")) {
+            } else if (entry.getKey().trim().equalsIgnoreCase("bag-algorithms")) {
                 c.setBagAlgorithms(entry.getValue().split(","));
             } else if (entry.getKey().trim().equalsIgnoreCase("serialization")) {
                 c.setBagSerialization(entry.getValue());

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -596,7 +596,7 @@ public class ArgParser {
                 c.setBagConfigPath(entry.getValue().toLowerCase());
             } else if (entry.getKey().trim().equalsIgnoreCase("bag-algorithms")) {
                 c.setBagAlgorithms(entry.getValue().split(","));
-            } else if (entry.getKey().trim().equalsIgnoreCase("serialization")) {
+            } else if (entry.getKey().trim().equalsIgnoreCase("bag-serialization")) {
                 c.setBagSerialization(entry.getValue());
             } else if (entry.getKey().equalsIgnoreCase("predicates")) {
                 c.setPredicates(entry.getValue().split(","));

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -287,7 +287,7 @@ public class ArgParser {
             config = parseConfigFileOptions(c);
             addSharedOptions(c, config);
         } catch (final ParseException ignore) {
-            logger.debug("Command line argments weren't valid for specifying a config file.");
+            logger.debug("Command line arguments weren't valid for specifying a config file.");
         }
         if (config == null) {
             // check for presence of the help flag

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -60,14 +60,8 @@ import com.esotericsoftware.yamlbeans.YamlWriter;
  */
 public class ArgParser {
 
-    /**
-     *
-     */
     private static final String BAG_CONFIG_OPTION_KEY = "bag-config";
 
-    /**
-     *
-     */
     private static final String BAG_PROFILE_OPTION_KEY = "bag-profile";
 
     private static final Logger logger = getLogger(ArgParser.class);
@@ -121,6 +115,13 @@ public class ArgParser {
                 .longOpt("binaries")
                 .hasArg(false)
                 .desc("When present this flag indicates that binaries should be imported/exported.")
+                .required(false).build());
+
+        // Import/export acl option
+        configOptions.addOption(Option.builder()
+                .longOpt("acls")
+                .hasArg(false)
+                .desc("When present this flag indicates that acls should be imported/exported.")
                 .required(false).build());
 
         // Retrieve external content
@@ -403,6 +404,7 @@ public class ArgParser {
         config.setMode(mode);
         config.setResource(cmd.getOptionValue('r'));
         config.setBaseDirectory(cmd.getOptionValue('d'));
+        config.setIncludeAcls(cmd.hasOption("acls"));
         config.setIncludeBinaries(cmd.hasOption('b'));
         config.setRetrieveExternal(cmd.hasOption('x'));
         config.setRetrieveInbound(cmd.hasOption('i'));
@@ -574,6 +576,8 @@ public class ArgParser {
                 c.setRdfLanguage(entry.getValue());
             } else if (entry.getKey().trim().equalsIgnoreCase("binaries")) {
                 c.setIncludeBinaries(parseBoolean("binaries", entry.getValue(), lineNumber));
+            } else if (entry.getKey().trim().equalsIgnoreCase("acls")) {
+                c.setIncludeAcls(parseBoolean("acls", entry.getValue(), lineNumber));
             } else if (entry.getKey().trim().equalsIgnoreCase("external")) {
                 c.setRetrieveExternal(parseBoolean("external", entry.getValue(), lineNumber));
             } else if (entry.getKey().trim().equalsIgnoreCase("inbound")) {

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -56,6 +56,7 @@ public class Config {
 
     private URI repositoryRoot;
 
+    private boolean includeAcls = false;
     private boolean includeBinaries = false;
     private boolean retrieveExternal = false;
     private boolean retrieveInbound = false;
@@ -537,6 +538,7 @@ public class Config {
         if (!this.getRdfLanguage().isEmpty()) {
             map.put("rdfLang", this.getRdfLanguage());
         }
+        map.put("acls", Boolean.toString(this.includeAcls));
         map.put("binaries", Boolean.toString(this.includeBinaries));
         map.put("external", Boolean.toString(this.retrieveExternal));
         map.put("inbound", Boolean.toString(this.retrieveInbound));
@@ -602,5 +604,21 @@ public class Config {
      */
     public void setRepositoryRoot(final String repositoryRoot) {
         this.repositoryRoot = URI.create(repositoryRoot);
+    }
+
+    /**
+     * Returns true if acls should be exported/imported
+     * @return include acls flag
+     */
+    public boolean isIncludeAcls() {
+        return includeAcls;
+    }
+
+    /**
+     * Set the flag to include acls
+     * @param includeAcls in export/import
+     */
+    public void setIncludeAcls(final boolean includeAcls) {
+        this.includeAcls = includeAcls;
     }
 }

--- a/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
+++ b/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
@@ -81,4 +81,7 @@ public abstract class FcrepoConstants {
     public static final Property MEMENTO = createProperty(MEMENTO_NAMESPACE + "Memento");
     public static final Property TIMEMAP = createProperty(MEMENTO_NAMESPACE + "TimeMap");
     public static final Property HAS_VERSION_LABEL = createProperty(REPOSITORY_NAMESPACE + "hasVersionLabel");
+
+    private static final String WEBAC_NAMESPACE = "http://fedora.info/definitions/v4/webac#";
+    public static final Property ACL_SOURCE = createProperty(WEBAC_NAMESPACE + "Acl");
 }

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -364,6 +364,8 @@ public class Exporter implements TransferProcess {
                 exportRdf(uri, null);
                 // Export versions for this container
                 exportVersions(uri);
+            } else if (uri.equals(URI.create(repositoryRoot.toString() + "/fcr:acl").normalize())) {
+                logger.info("The repository default root ACL is not being exported: {}", uri);
             } else {
                 logger.error("Resource is not an LDP Container, LDP RDFSource,  or an LDP NonRDFSource: {}", uri);
                 exportLogger.error("Resource is not an LDP Container, LDP RDFSource, or an LDP NonRDFSource: {}", uri);

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -603,14 +603,10 @@ public class Exporter implements TransferProcess {
         final URI timemapURI;
         try (FcrepoResponse response = client().head(uri).disableRedirects().perform()) {
             checkValidResponse(response, uri, config.getUsername());
-            if (response.getLinkHeaders("type").stream()
-                .filter(x -> x.toString().equals(MEMENTO.getURI()))
-                .count() > 0) {
+            if (response.getLinkHeaders("type").contains(URI.create(MEMENTO.toString()))) {
                 logger.trace("Resource {} is a memento and therefore not versioned:  ", uri);
                 return;
-            } else if (response.getLinkHeaders("type").stream()
-                .filter(x -> x.toString().equals(TIMEMAP.getURI()))
-                .count() > 0) {
+            } else if (response.getLinkHeaders("type").contains(URI.create(TIMEMAP.toString()))) {
                 logger.trace("Resource {} is a timemap and therefore not versioned:  ", uri);
                 return;
             }

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -368,7 +368,7 @@ public class Exporter implements TransferProcess {
                 exportLogger.error("Resource is not an LDP Container, LDP RDFSource, or an LDP NonRDFSource: {}", uri);
             }
 
-            if (acl != null) {
+            if (acl != null && config.isIncludeAcls()) {
                 export(acl);
             }
 

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
@@ -436,7 +437,7 @@ public class Exporter implements TransferProcess {
             checkValidResponse(response, uri, config.getUsername());
             logger.info("Exporting rdf: {}", uri);
 
-            final String responseBody = IOUtils.toString(response.getBody(), "UTF-8");
+            final String responseBody = IOUtils.toString(response.getBody(), StandardCharsets.UTF_8);
             final Model model = createDefaultModel().read(new ByteArrayInputStream(responseBody.getBytes()),
                     null, config.getRdfLanguage());
             Set<URI> inboundMembers = null;

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -65,6 +65,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -85,7 +86,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.loc.repository.bagit.domain.Manifest;
 import gov.loc.repository.bagit.verify.BagVerifier;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.ext.com.google.common.base.Charsets;
 import org.apache.jena.rdf.model.Property;
 import org.duraspace.bagit.BagDeserializer;
 import org.duraspace.bagit.BagProfile;
@@ -360,7 +360,7 @@ public class Importer implements TransferProcess {
                     response.getStatusCode());
                 throw new RuntimeException("Error while importing membership resource " + f.getAbsolutePath()
                         + " (" + response.getStatusCode() + "): "
-                        + IOUtils.toString(response.getBody(), Charsets.UTF_8));
+                        + IOUtils.toString(response.getBody(), StandardCharsets.UTF_8));
             } else {
                 logger.info("Imported membership resource {}: {}", f.getAbsolutePath(), uri);
                 importLogger.info("import {} to {}", f.getAbsolutePath(), uri);
@@ -503,7 +503,8 @@ public class Importer implements TransferProcess {
                 throw new AuthenticationRequiredRuntimeException();
             } else if (response.getStatusCode() > 204 || response.getStatusCode() < 200) {
                 final String message = "Error while importing " + f.getAbsolutePath() + " ("
-                        + response.getStatusCode() + "): " + IOUtils.toString(response.getBody(), Charsets.UTF_8);
+                        + response.getStatusCode() + "): " + IOUtils.toString(response.getBody(),
+                                                                              StandardCharsets.UTF_8);
                 logger.error(message);
                 importLogger.error("Error importing {} to {}, received {}", f.getAbsolutePath(), destinationUri,
                     response.getStatusCode());
@@ -635,7 +636,7 @@ public class Importer implements TransferProcess {
             return binaryBuilder(binaryURI, binaryFile, contentType, model).perform();
         } else {
             logger.error("Error while importing {} ({}): {}", binaryFile.getAbsolutePath(),
-                    binaryResponse.getStatusCode(), IOUtils.toString(binaryResponse.getBody(), Charsets.UTF_8));
+                    binaryResponse.getStatusCode(), IOUtils.toString(binaryResponse.getBody(), StandardCharsets.UTF_8));
             return binaryResponse;
         }
     }

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -140,8 +140,8 @@ public class Importer implements TransferProcess {
     private Map<String, String> bagItFileMap;
     private String digestAlgorithm;
 
-    private Logger importLogger;
-    private AtomicLong successCount = new AtomicLong(); // set to zero at start
+    private final Logger importLogger;
+    private final AtomicLong successCount = new AtomicLong(); // set to zero at start
 
     final static Set<String> INTERACTION_MODELS = new HashSet<>(Arrays.asList(DIRECT_CONTAINER.getURI(),
                                                                               INDIRECT_CONTAINER.getURI()));

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -469,6 +469,9 @@ public class Importer implements TransferProcess {
                     logger.info("Importing binary {}", sourceRelativePath);
                     response = importBinary(destinationUri, model);
                 } else if (aclResource.hasNext()) {
+                    if (!config.isIncludeAcls()) {
+                        return;
+                    }
                     destinationUri = new URI(aclResource.nextResource().getURI());
                     logger.info("Importing acl {}", destinationUri);
 

--- a/src/main/java/org/fcrepo/importexport/importer/Importer.java
+++ b/src/main/java/org/fcrepo/importexport/importer/Importer.java
@@ -19,7 +19,6 @@ package org.fcrepo.importexport.importer;
 
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
@@ -275,8 +274,8 @@ public class Importer implements TransferProcess {
 
     private void discoverMembershipResources(final File dir) {
         if (dir.listFiles() != null) {
-            stream(dir.listFiles()).filter(File::isFile).forEach(f -> parseMembershipResources(f));
-            stream(dir.listFiles()).filter(File::isDirectory).forEach(d -> discoverMembershipResources(d));
+            stream(dir.listFiles()).filter(File::isFile).forEach(this::parseMembershipResources);
+            stream(dir.listFiles()).filter(File::isDirectory).forEach(this::discoverMembershipResources);
         }
     }
 
@@ -331,10 +330,10 @@ public class Importer implements TransferProcess {
 
     private void importRelatedResources() {
         if (relatedResources.size() > 0) {
-            final List<URI> referenceResources = relatedResources.stream().collect(toList());
+            final List<URI> referenceResources = new ArrayList<>(relatedResources);
             relatedResources.clear();
             // loop through for nested related resources
-            referenceResources.stream().forEach(uri -> {
+            referenceResources.forEach(uri -> {
                 logger.info("Importing related resources {} ...", uri);
                 processImport(uri);
             });
@@ -342,7 +341,7 @@ public class Importer implements TransferProcess {
     }
 
     private void importMembershipResources() {
-        membershipResources.stream().forEach(uri -> importMembershipResource(uri));
+        membershipResources.forEach(this::importMembershipResource);
     }
 
     private void importMembershipResource(final URI uri) {
@@ -386,8 +385,8 @@ public class Importer implements TransferProcess {
         // created as peartree nodes which can't be updated with properties
         // later.
         if (dir.listFiles() != null) {
-            stream(dir.listFiles()).filter(File::isFile).forEach(file -> importFile(file));
-            stream(dir.listFiles()).filter(File::isDirectory).forEach(directory -> importDirectory(directory));
+            stream(dir.listFiles()).filter(File::isFile).forEach(this::importFile);
+            stream(dir.listFiles()).filter(File::isDirectory).forEach(this::importDirectory);
         }
     }
 

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -427,6 +427,7 @@ public class ExporterTest {
         final Config args = new Config();
         args.setMode("export");
         args.setBaseDirectory(basedir);
+        args.setIncludeAcls(true);
         args.setIncludeBinaries(true);
         args.setPredicates(predicates);
         args.setRdfLanguage("application/ld+json");

--- a/src/test/java/org/fcrepo/importexport/importer/ImporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/importer/ImporterTest.java
@@ -186,7 +186,7 @@ public class ImporterTest {
         final FcrepoResponse binResponse = mock(FcrepoResponse.class);
         when(client.put(eq(binaryURI))).thenReturn(binBuilder);
         when(binBuilder.body(isA(InputStream.class), isA(String.class))).thenReturn(binBuilder);
-        when(binBuilder.digest(isA(String.class))).thenReturn(binBuilder);
+        when(binBuilder.digestSha1(isA(String.class))).thenReturn(binBuilder);
         when(binBuilder.filename(any())).thenReturn(binBuilder);
         when(binBuilder.ifUnmodifiedSince(any())).thenReturn(binBuilder);
         when(binBuilder.perform()).thenReturn(binResponse);
@@ -228,7 +228,7 @@ public class ImporterTest {
         final Importer importer = new Importer(binaryArgs, clientBuilder);
         importer.run();
         verify(client).put(binaryURI);
-        verify(binBuilder).digest(eq("2a6d6229e30f667c60d406f7bf44d834e52d11b7"));
+        verify(binBuilder).digestSha1(eq("2a6d6229e30f667c60d406f7bf44d834e52d11b7"));
         verify(binBuilder).body(isA(InputStream.class), eq("application/x-www-form-urlencoded"));
         verify(client).put(binaryDescriptionURI);
     }

--- a/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
@@ -287,6 +287,7 @@ public class BagItIT extends AbstractResourceIT {
         config.setUsername(USERNAME);
         config.setPassword(PASSWORD);
         config.setBagProfile(DEFAULT_BAG_PROFILE);
+        config.setIncludeAcls(true);
         config.setIncludeBinaries(true);
         config.setLegacy(true);
 

--- a/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/BagItIT.java
@@ -275,6 +275,7 @@ public class BagItIT extends AbstractResourceIT {
         final URI rootURI = URI.create(serverAddress);
         final URI resourceURI = URI.create(serverAddress + "testBagImport");
         final URI metadataURI = URI.create(serverAddress + "image0/fcr:metadata");
+        final URI aclURI = URI.create(serverAddress + "image0/fcr:acl");
         final String bagPath = TARGET_DIR + "/test-classes/sample/bag";
 
         final Config config = new Config();
@@ -302,6 +303,7 @@ public class BagItIT extends AbstractResourceIT {
         // Resource does exist.
         assertTrue(exists(resourceURI));
         assertTrue(exists(metadataURI));
+        assertTrue(exists(aclURI));
 
         final String metadata = getAsString(metadataURI);
         assertNotNull(metadata);

--- a/src/test/java/org/fcrepo/importexport/integration/ExecutableJarIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExecutableJarIT.java
@@ -35,6 +35,7 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -238,7 +239,7 @@ public class ExecutableJarIT extends AbstractResourceIT {
 
         builder.directory(new File(TARGET_DIR));
         final Process process = builder.start();
-        logger.debug("Output of jar run: {}", IOUtils.toString(process.getInputStream()));
+        logger.debug("Output of jar run: {}", IOUtils.toString(process.getInputStream(), Charset.defaultCharset()));
         return process;
     }
 

--- a/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
@@ -284,6 +284,7 @@ public class ExporterIT extends AbstractResourceIT {
         config.setRdfLanguage(DEFAULT_RDF_LANG);
         config.setUsername(USERNAME);
         config.setPassword(PASSWORD);
+        config.setIncludeAcls(true);
         config.setIncludeVersions(false);
         config.setIncludeBinaries(false);
 

--- a/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ImporterIT.java
@@ -33,6 +33,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.UUID;
 
 import org.apache.jena.graph.Graph;
@@ -171,7 +172,7 @@ public class ImporterIT extends AbstractResourceIT {
 
         // verify member resource content
         final FcrepoResponse response = clientBuilder.build().get(linkTo).accept("text/plain").perform();
-        final String triples = IOUtils.toString(response.getBody());
+        final String triples = IOUtils.toString(response.getBody(), Charset.defaultCharset());
         final String hasfileTriple = "<" + linkTo + "> <http://pcdm.org/models#hasFile> <" + linkToFile1 + "> .";
         assertEquals(1, count(triples, hasfileTriple));
     }

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -345,7 +346,8 @@ public class RoundtripIT extends AbstractResourceIT {
         assertTrue(contModel.contains(container, RDF_TYPE, CONTAINER));
 
         assertTrue(binaryFile.exists() && binaryFile.isFile());
-        assertEquals("this is some content", IOUtils.toString(new FileInputStream(binaryFile)));
+        assertEquals("this is some content", IOUtils.toString(new FileInputStream(binaryFile),
+                                                              Charset.defaultCharset()));
         assertEquals(20L, binaryFile.length());
 
         assertTrue(descFile.exists() && descFile.isFile());
@@ -441,7 +443,7 @@ public class RoundtripIT extends AbstractResourceIT {
                 + config.getRdfExtension());
 
         assertTrue(binaryFile.exists() && binaryFile.isFile());
-        assertEquals("", IOUtils.toString(new FileInputStream(binaryFile)));
+        assertEquals("", IOUtils.toString(new FileInputStream(binaryFile), Charset.defaultCharset()));
         assertEquals(0L, binaryFile.length());
         assertTrue(binaryFileHeaders.exists() && binaryFileHeaders.isFile());
 
@@ -512,7 +514,7 @@ public class RoundtripIT extends AbstractResourceIT {
         assertTrue(contModel.contains(container, RDF_TYPE, CONTAINER));
 
         assertTrue(binaryFile.exists() && binaryFile.isFile());
-        assertEquals(contents, IOUtils.toString(new FileInputStream(binaryFile)));
+        assertEquals(contents, IOUtils.toString(new FileInputStream(binaryFile), Charset.defaultCharset()));
         assertEquals(binaryFileLength, binaryFile.length());
         assertTrue(binaryFileHeaders.exists() && binaryFileHeaders.isFile());
 
@@ -545,7 +547,7 @@ public class RoundtripIT extends AbstractResourceIT {
         final URI childURI = URI.create(parentURI.toString() + "/child1");
         final URI fileURI = URI.create(parentURI.toString() + "/file1");
         final File binaryFile = new File("src/test/resources/binary.txt");
-        final String binaryContent = IOUtils.toString(new FileInputStream(binaryFile));
+        final String binaryContent = IOUtils.toString(new FileInputStream(binaryFile), Charset.defaultCharset());
 
         final FcrepoResponse response = createBody(uri, stream, "text/turtle");
         assertEquals(SC_CREATED, response.getStatusCode());
@@ -569,7 +571,7 @@ public class RoundtripIT extends AbstractResourceIT {
     public void testRoundtripOverwriteBinary() throws Exception {
         final URI fileURI = URI.create(serverAddress + UUID.randomUUID());
         final File binaryFile = new File("src/test/resources/binary.txt");
-        final String binaryContent = IOUtils.toString(new FileInputStream(binaryFile));
+        final String binaryContent = IOUtils.toString(new FileInputStream(binaryFile), Charset.defaultCharset());
 
         final FcrepoResponse response = createBody(fileURI, new FileInputStream(binaryFile), "text/plain");
         assertEquals(SC_CREATED, response.getStatusCode());
@@ -586,7 +588,7 @@ public class RoundtripIT extends AbstractResourceIT {
     public void testRoundtripRdfBinary() throws Exception {
         final URI fileURI = URI.create(serverAddress + UUID.randomUUID());
         final File binaryFile = new File("src/test/resources/binary.txt");
-        final String binaryContent = IOUtils.toString(new FileInputStream(binaryFile));
+        final String binaryContent = IOUtils.toString(new FileInputStream(binaryFile), Charset.defaultCharset());
 
         // create a binary with an RDF content type
         final FcrepoResponse response = clientBuilder.build().put(fileURI)

--- a/src/test/resources/sample/bag/bag-info.txt
+++ b/src/test/resources/sample/bag/bag-info.txt
@@ -1,5 +1,5 @@
-Bag-Size : 22 KB
-Payload-Oxum : 22178.4
+Bag-Size : 6KB
+Payload-Oxum : 6919.5
 Bagging-Date : 2016-12-13
 Source-Organization: fcrepo-import-export
 Organization-Address: localhost

--- a/src/test/resources/sample/bag/data/fcrepo/rest/image0/fcr%3Aacl.ttl
+++ b/src/test/resources/sample/bag/data/fcrepo/rest/image0/fcr%3Aacl.ttl
@@ -1,0 +1,24 @@
+@prefix webac:  <http://fedora.info/definitions/v4/webac#> .
+@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
+@prefix ldp:  <http://www.w3.org/ns/ldp#> .
+
+<http://localhost:8080/fcrepo/rest/image0/fcr:acl>
+        rdf:type               fedora:Resource ;
+        rdf:type               webac:Acl ;
+        fedora:lastModifiedBy  "bypassAdmin" ;
+        fedora:createdBy       "bypassAdmin" ;
+        fedora:created         "2020-09-11T18:03:03.109Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        fedora:lastModified    "2020-09-11T18:03:03.109Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+<http://localhost:8080/fcrepo/rest/image0/fcr:acl#authz>
+        rdf:type      acl:Authorization ;
+        acl:accessTo  <http://localhost:8080/fcrepo/rest/image0> ;
+        acl:mode      acl:Read ;
+        acl:agent     "testuser" .
+
+<http://localhost:8080/fcrepo/rest/image0/fcr:acl>
+        rdf:type  ldp:RDFSource ;
+        rdf:type  ldp:Container ;
+        rdf:type  ldp:BasicContainer .

--- a/src/test/resources/sample/bag/manifest-sha1.txt
+++ b/src/test/resources/sample/bag/manifest-sha1.txt
@@ -2,3 +2,4 @@
 c537ab534deef7493140106c2151eccf2a219b8e  data/fcrepo/rest/testBagImport.ttl
 9b040aa0ceca4cdff2069b46769dcf1f04214833  data/fcrepo/rest/testBagBtRImport.ttl
 da39a3ee5e6b4b0d3255bfef95601890afd80709  data/fcrepo/rest/image0.binary
+f6ed247107b2c24b55de65fbd13e489df3dcc780  data/fcrepo/rest/image0/fcr%3Aacl.ttl

--- a/src/test/resources/sample/bag/manifest-sha256.txt
+++ b/src/test/resources/sample/bag/manifest-sha256.txt
@@ -2,3 +2,4 @@
 adb10fee9c3f6834edf7564723f7cb4c4f56f07c0ceb6508f20bf7ac3e695a22  data/fcrepo/rest/testBagImport.ttl
 75b50b7c7bb0ab2d88672b63763172ee5fa1df05c949119bcfc2432d7102adbf  data/fcrepo/rest/testBagBtRImport.ttl
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  data/fcrepo/rest/image0.binary
+dd4a2b79e45b9efbb6b3f317e675aa2ea494ea6a9ba6f8446b81e2879fb78c38  data/fcrepo/rest/image0/fcr%3Aacl.ttl

--- a/src/test/resources/sample/bag/tagmanifest-sha1.txt
+++ b/src/test/resources/sample/bag/tagmanifest-sha1.txt
@@ -1,3 +1,3 @@
-3ef7661f339c58d552c1efb83fe961a7a261c295  bag-info.txt
 f6a30323d14f50fbf707a0117d5ce1a6852b6a2b  bagit.txt
-4a066f099d5ce2baf9b60efbe51cee0a52d2e254  manifest-sha1.txt
+57bf9cf7f0c7149327e9d0a6e46db6cc07a2b7b0  manifest-sha1.txt
+d9fa5be93e9362fd398a858ea7761d73181b2f88  bag-info.txt


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3333

Potentially resolves https://jira.lyrasis.org/browse/FCREPO-2983 as well (see notes)

* Update Importer to use correct URI when importing acls
* Add cli argument for importing/exporting acls
* Remove use of deprecated APIs
* Remove unnecessary stream usage

--------------------------------------

# Notes

* I only tested using acls as they are the majority of what is outlined under the Web Access Control documentation. I'm not sure if there are other types of WebAC which should be tested for 2983.
* There is only a long option for the cli argument, if needed a short option can be added as well
* I had to enable relaxed handling (`-Dfcrepo.properties.management=relaxed`) in order for certain metadata to be accepted, e.g. `fedora:created`. Before doing this I was receiving errors when trying to upload both `fcr:acl` and `fcr:metadata` resources. I'm not sure if it's worth it to create a ticket to have the import-export-tool also have a strict option or possibly add a note in the readme about it.

--------------------------------------

# Testing

1. Start a fresh fedora repository, e.g. with the one-click server `java -Dfcrepo.properties.management=relaxed -jar fcrepo-webapp-5.1.1-jetty-console.jar`
2. Create a binary in the repository
3. Create an acl for the binary
    ```
    @prefix acl: <http://www.w3.org/ns/auth/acl#>.

    <#authz> a acl:Authorization;
       acl:accessTo </rest/foo>;
       acl:agent "testuser";
       acl:mode acl:Read.
    ```
4. Add the acl to the binary: `curl -X PUT -H "Content-Type: text/turtle" --data-binary @acl.ttl -u fedoraAdmin:secret3 "http://192.168.99.100:8080/rest/binary/fcr:acl"`
5. Create a bag-config.yml for export
   ```
   bag-info.txt:
     Source-Organization: fcrepo-import-export
     Organization-Address: localhost
     External-Description: BagIt Bag
   ```
5. Run the exporter, specifying that acls should be exported
   ```
   java -jar target/fcrepo-import-export-0.4.0-SNAPSHOT.jar --mode export --resource http://localhost:8080/rest --dir fcrepo-3333  --binaries --acls --bag-profile beyondtherepository --bag-config bag-config.yml --bag-algorithms sha1 --user fedoraAdmin:secret3
   ```
6. Check the exported bag for the acls
7. Refresh the fedora repository
    a. Stop the server
    b. Clear the data if necessary (e.g. rm the `fcrepo4-data` created by the one-click or `docker-compose down` for docker)
    c. Restart the server
8. Run the importer
   ```
   java -jar target/fcrepo-import-export-0.4.0-SNAPSHOT.jar --mode import --resource http://localhost:8080/rest --dir fcrepo-3333  --binaries --acls --bag-profile beyondtherepository --bag-config bag-config.yml --bag-algorithms sha1 --user fedoraAdmin:secret3
   ```
9. Check that the acl exists for the binary: `curl -u fedoraAdmin:secret3 http://192.168.99.100:8080/rest/binary/fcr:acl`