### PR TITLE
add flag for omitting membership triples

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ That configuration file is [Yaml](http://yaml.org) and allows for the following 
 * overwriteTombstones: [true|false] # whether to replace tombstones of previously deleted resources
 * external: [true|false] # whether to retrieve external content binaries when exporting
 * inbound: [true|false] # whether to export inbound references when exporting
+* membership: [true|false] # whether to export membership references when exporting
 * map: Old and new base URIs, separated by comma, to map URIs when importing.
 * versions: [true|false] # whether to export versions of resources and binaries.
 * resource: The resource to export/import

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -137,11 +137,11 @@ public class ArgParser {
                 .desc("When present this flag indicates that inbound references should be exported.")
                 .required(false).build());
 
-        // Omit membership
+        // Include membership
         configOptions.addOption(Option.builder()
-                .longOpt("omit-membership")
+                .longOpt("membership")
                 .hasArg(false)
-                .desc("When present this flag indicates that membership references should NOT be exported.")
+                .desc("When present this flag indicates that membership references should be exported.")
                 .required(false).build());
 
         // Write config file
@@ -413,7 +413,7 @@ public class ArgParser {
         config.setIncludeBinaries(cmd.hasOption('b'));
         config.setRetrieveExternal(cmd.hasOption('x'));
         config.setRetrieveInbound(cmd.hasOption('i'));
-        config.setOmitMembership(cmd.hasOption("omit-membership"));
+        config.setIncludeMembership(cmd.hasOption("membership"));
         config.setOverwriteTombstones(cmd.hasOption('t'));
         config.setLegacy(cmd.hasOption("L"));
         config.setIncludeVersions(cmd.hasOption('V'));

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -137,6 +137,13 @@ public class ArgParser {
                 .desc("When present this flag indicates that inbound references should be exported.")
                 .required(false).build());
 
+        // Omit membership
+        configOptions.addOption(Option.builder()
+                .longOpt("omit-membership")
+                .hasArg(false)
+                .desc("When present this flag indicates that membership references should NOT be exported.")
+                .required(false).build());
+
         // Write config file
         configOptions.addOption(Option.builder("w")
                 .longOpt("writeConfig")
@@ -406,6 +413,7 @@ public class ArgParser {
         config.setIncludeBinaries(cmd.hasOption('b'));
         config.setRetrieveExternal(cmd.hasOption('x'));
         config.setRetrieveInbound(cmd.hasOption('i'));
+        config.setOmitMembership(cmd.hasOption("omit-membership"));
         config.setOverwriteTombstones(cmd.hasOption('t'));
         config.setLegacy(cmd.hasOption("L"));
         config.setIncludeVersions(cmd.hasOption('V'));

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -59,7 +59,7 @@ public class Config {
     private boolean includeBinaries = false;
     private boolean retrieveExternal = false;
     private boolean retrieveInbound = false;
-    private boolean omitMembership = false;
+    private boolean includeMembership = false;
     private boolean overwriteTombstones = false;
     private boolean legacy = false;
     private boolean includeVersions = false;
@@ -194,19 +194,19 @@ public class Config {
     /**
      * Sets flag indicating whether or not membership should be included when exporting direct and indirect containers.
      *
-     * @param omitMembership Whether to omit membership
+     * @param includeMembership Whether to include membership
      */
-    public void setOmitMembership(final boolean omitMembership) {
-        this.omitMembership = omitMembership;
+    public void setIncludeMembership(final boolean includeMembership) {
+        this.includeMembership = includeMembership;
     }
 
     /**
-     * Get the omit membership flag.
+     * Get the include membership flag.
      *
-     * @return true if membership should be omitted
+     * @return true if membership should be included
      */
-    public boolean omitMembership() {
-        return omitMembership;
+    public boolean includeMembership() {
+        return includeMembership;
     }
 
     /**
@@ -559,7 +559,7 @@ public class Config {
         map.put("binaries", Boolean.toString(this.includeBinaries));
         map.put("external", Boolean.toString(this.retrieveExternal));
         map.put("inbound", Boolean.toString(this.retrieveInbound));
-        map.put("omit-membership", Boolean.toString(this.omitMembership));
+        map.put("membership", Boolean.toString(this.includeMembership));
         map.put("overwriteTombstones", Boolean.toString(this.overwriteTombstones()));
         map.put("legacyMode", Boolean.toString(this.isLegacy()));
         map.put("versions", Boolean.toString(this.includeVersions));

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -17,11 +17,8 @@
  */
 package org.fcrepo.importexport.common;
 
-import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
-import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
-import static org.fcrepo.importexport.common.TransferProcess.IMPORT_EXPORT_LOG_PREFIX;
-import static org.slf4j.LoggerFactory.getLogger;
-import static org.slf4j.helpers.NOPLogger.NOP_LOGGER;
+import org.apache.jena.riot.Lang;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.net.URI;
@@ -29,8 +26,11 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jena.riot.Lang;
-import org.slf4j.Logger;
+import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
+import static org.fcrepo.importexport.common.TransferProcess.IMPORT_EXPORT_LOG_PREFIX;
+import static org.slf4j.LoggerFactory.getLogger;
+import static org.slf4j.helpers.NOPLogger.NOP_LOGGER;
 
 
 /**
@@ -59,6 +59,7 @@ public class Config {
     private boolean includeBinaries = false;
     private boolean retrieveExternal = false;
     private boolean retrieveInbound = false;
+    private boolean omitMembership = false;
     private boolean overwriteTombstones = false;
     private boolean legacy = false;
     private boolean includeVersions = false;
@@ -188,6 +189,24 @@ public class Config {
      */
     public boolean retrieveInbound() {
         return retrieveInbound;
+    }
+
+    /**
+     * Sets flag indicating whether or not membership should be included when exporting direct and indirect containers.
+     *
+     * @param omitMembership Whether to omit membership
+     */
+    public void setOmitMembership(final boolean omitMembership) {
+        this.omitMembership = omitMembership;
+    }
+
+    /**
+     * Get the omit membership flag.
+     *
+     * @return true if membership should be omitted
+     */
+    public boolean omitMembership() {
+        return omitMembership;
     }
 
     /**
@@ -540,6 +559,7 @@ public class Config {
         map.put("binaries", Boolean.toString(this.includeBinaries));
         map.put("external", Boolean.toString(this.retrieveExternal));
         map.put("inbound", Boolean.toString(this.retrieveInbound));
+        map.put("omit-membership", Boolean.toString(this.omitMembership));
         map.put("overwriteTombstones", Boolean.toString(this.overwriteTombstones()));
         map.put("legacyMode", Boolean.toString(this.isLegacy()));
         map.put("versions", Boolean.toString(this.includeVersions));

--- a/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
+++ b/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
@@ -18,11 +18,11 @@
 package org.fcrepo.importexport.common;
 
 
-import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
-
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
+
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 
 /**
  * @author awoods
@@ -52,6 +52,7 @@ public abstract class FcrepoConstants {
     public static final Resource INDIRECT_CONTAINER = createResource(LDP_NAMESPACE + "IndirectContainer");
 
     public static final Property MEMBERSHIP_RESOURCE = createProperty(LDP_NAMESPACE + "membershipResource");
+    public static final Property PREFER_MEMBERSHIP = createProperty(LDP_NAMESPACE + "PreferMembership");
     public static final Property NON_RDF_SOURCE = createProperty(LDP_NAMESPACE + "NonRDFSource");
     public static final Property RDF_SOURCE = createProperty(LDP_NAMESPACE + "RDFSource");
     public static final Property CONTAINS = createProperty(LDP_NAMESPACE + "contains");

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -17,54 +17,6 @@
  */
 package org.fcrepo.importexport.exporter;
 
-import static org.apache.commons.codec.binary.Hex.encodeHex;
-import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
-import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
-import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
-import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
-import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
-import static org.fcrepo.importexport.common.FcrepoConstants.HEADERS_EXTENSION;
-import static org.fcrepo.importexport.common.FcrepoConstants.INBOUND_REFERENCES;
-import static org.fcrepo.importexport.common.FcrepoConstants.MEMENTO;
-import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
-import static org.fcrepo.importexport.common.FcrepoConstants.RDF_SOURCE;
-import static org.fcrepo.importexport.common.FcrepoConstants.REPOSITORY_NAMESPACE;
-import static org.fcrepo.importexport.common.FcrepoConstants.TIMEMAP;
-import static org.fcrepo.importexport.common.TransferProcess.checkValidResponse;
-import static org.fcrepo.importexport.common.TransferProcess.fileForBinary;
-import static org.fcrepo.importexport.common.TransferProcess.fileForExternalResources;
-import static org.fcrepo.importexport.common.TransferProcess.fileForURI;
-import static org.fcrepo.importexport.common.TransferProcess.isRepositoryRoot;
-import static org.fcrepo.importexport.common.UriUtils.withSlash;
-import static org.fcrepo.importexport.common.UriUtils.withoutSlash;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.MessageDigest;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
@@ -88,6 +40,54 @@ import org.fcrepo.client.GetBuilder;
 import org.fcrepo.importexport.common.Config;
 import org.fcrepo.importexport.common.TransferProcess;
 import org.slf4j.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.codec.binary.Hex.encodeHex;
+import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
+import static org.fcrepo.importexport.common.FcrepoConstants.HEADERS_EXTENSION;
+import static org.fcrepo.importexport.common.FcrepoConstants.INBOUND_REFERENCES;
+import static org.fcrepo.importexport.common.FcrepoConstants.MEMENTO;
+import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
+import static org.fcrepo.importexport.common.FcrepoConstants.PREFER_MEMBERSHIP;
+import static org.fcrepo.importexport.common.FcrepoConstants.RDF_SOURCE;
+import static org.fcrepo.importexport.common.FcrepoConstants.REPOSITORY_NAMESPACE;
+import static org.fcrepo.importexport.common.FcrepoConstants.TIMEMAP;
+import static org.fcrepo.importexport.common.TransferProcess.checkValidResponse;
+import static org.fcrepo.importexport.common.TransferProcess.fileForBinary;
+import static org.fcrepo.importexport.common.TransferProcess.fileForExternalResources;
+import static org.fcrepo.importexport.common.TransferProcess.fileForURI;
+import static org.fcrepo.importexport.common.TransferProcess.isRepositoryRoot;
+import static org.fcrepo.importexport.common.UriUtils.withSlash;
+import static org.fcrepo.importexport.common.UriUtils.withoutSlash;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Fedora Export Utility
@@ -426,11 +426,19 @@ public class Exporter implements TransferProcess {
             return;
         }
 
-        GetBuilder getBuilder = client().get(uri).accept(config.getRdfLanguage());
+        final GetBuilder getBuilder = client().get(uri).accept(config.getRdfLanguage());
+
+        final List<URI> includeUris = new ArrayList<>();
+        final List<URI> omitUris = new ArrayList<>();
+
         if (config.retrieveInbound()) {
-            getBuilder = getBuilder.preferRepresentation(
-                Arrays.asList(URI.create(INBOUND_REFERENCES.getURI())), null);
+            includeUris.add(URI.create(INBOUND_REFERENCES.getURI()));
         }
+        if (config.omitMembership()) {
+            omitUris.add(URI.create(PREFER_MEMBERSHIP.getURI()));
+        }
+
+        getBuilder.preferRepresentation(includeUris, omitUris);
 
         try (FcrepoResponse response = getBuilder.perform()) {
             checkValidResponse(response, uri, config.getUsername());

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -434,7 +434,7 @@ public class Exporter implements TransferProcess {
         if (config.retrieveInbound()) {
             includeUris.add(URI.create(INBOUND_REFERENCES.getURI()));
         }
-        if (config.omitMembership()) {
+        if (!config.includeMembership()) {
             omitUris.add(URI.create(PREFER_MEMBERSHIP.getURI()));
         }
 

--- a/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
@@ -437,7 +437,7 @@ public class ExporterIT extends AbstractResourceIT {
         config.setMode("export");
         config.setBaseDirectory(TARGET_DIR + "/" + uuid);
         config.setResource(baseURI);
-        config.setOmitMembership(true);
+        config.setIncludeMembership(false);
         config.setUsername(USERNAME);
         config.setPassword(PASSWORD);
 

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -658,6 +658,7 @@ public class RoundtripIT extends AbstractResourceIT {
         config.setMode("export");
         config.setBaseDirectory(TARGET_DIR + File.separator + UUID.randomUUID());
         config.setIncludeBinaries(includeBinary);
+        config.setOmitMembership(false);
         config.setResource(uri);
         config.setPredicates(new String[]{ CONTAINS.toString() });
         config.setRdfExtension(DEFAULT_RDF_EXT);

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -658,7 +658,7 @@ public class RoundtripIT extends AbstractResourceIT {
         config.setMode("export");
         config.setBaseDirectory(TARGET_DIR + File.separator + UUID.randomUUID());
         config.setIncludeBinaries(includeBinary);
-        config.setOmitMembership(false);
+        config.setIncludeMembership(true);
         config.setResource(uri);
         config.setPredicates(new String[]{ CONTAINS.toString() });
         config.setRdfExtension(DEFAULT_RDF_EXT);


### PR DESCRIPTION
**Jira:** https://jira.lyrasis.org/browse/FCREPO-3427

## What this does

Adds a flag, `--omit-membership` that is used to omit membership triples in exports. This is required when migration from F5 to F6 because the membership triples are not stored in the user RDF.

## How to test

Run an export using the new flag and very that the exported containers do not have membership triples. Here's a script for creating direct and indirect containers:

```
echo -e '@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Object .' | curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/objects -v -H "Content-Type: text/turtle" -X PUT --data-binary @-

echo -e '@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Object .' | curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/objects/raven -v -H "Content-Type: text/turtle" -X PUT --data-binary @-

echo -e '@prefix ldp: <http://www.w3.org/ns/ldp#>\n@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Object ;\nldp:membershipResource </rest/objects/raven/> ;\nldp:hasMemberRelation pcdm:hasMember .' | curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/objects/raven/pages -v -H'Link: <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"' -H "Content-Type: text/turtle" -X PUT --data-binary @-

echo -e '@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Object .' | curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/objects/raven/pages/cover -v -H "Content-Type: text/turtle" -X PUT --data-binary @-

echo -e '@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Object .' | curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/objects/raven/pages/page0 -v -H "Content-Type: text/turtle" -X PUT --data-binary @-

echo -e '@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Object .' | curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/objects/raven/pages/page1 -v -H "Content-Type: text/turtle" -X PUT --data-binary @-

echo -e '@prefix ldp: <http://www.w3.org/ns/ldp#>\n@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Object ;\nldp:membershipResource </rest/objects/raven/pages/cover> ;\nldp:hasMemberRelation pcdm:hasFile .' | curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/objects/raven/pages/cover/files -v -H'Link: <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"' -H "Content-Type: text/turtle" -X PUT --data-binary @-

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/objects/raven/pages/cover/files/cover.txt -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "This is a cover"

echo -e 'PREFIX pcdm: <http://pcdm.org/models#>\nINSERT {\n  <> a pcdm:File\n} WHERE {\n}' | curl -u fedoraAdmin:fedoraAdmin -i -XPATCH -H"Content-Type: application/sparql-update" http://localhost:8080/rest/objects/raven/pages/cover/files/cover.txt/fcr:metadata --data-binary @-

echo -e '@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Object .' | curl -i -XPUT -H"Content-Type: text/turtle" http://localhost:8080/rest/collections --data-binary @-

echo -e '@prefix pcdm: <http://pcdm.org/models#>\n\n<> a pcdm:Collection .' | curl -i -XPUT -H"Content-Type: text/turtle" http://localhost:8080/rest/collections/poe --data-binary @-

echo -e '@prefix ldp: <http://www.w3.org/ns/ldp#>\n@prefix pcdm: <http://pcdm.org/models#>\n@prefix ore: <http://www.openarchives.org/ore/terms/>\n\n<> a pcdm:Object ;\nldp:membershipResource </rest/collections/poe/> ;\nldp:hasMemberRelation pcdm:hasMember ;\nldp:insertedContentRelation ore:proxyFor .' | curl -i -XPUT -H"Content-Type: text/turtle" -H'Link: <http://www.w3.org/ns/ldp#IndirectContainer>;rel="type"' http://localhost:8080/rest/collections/poe/members --data-binary @-

echo -e '@prefix pcdm: <http://pcdm.org/models#>\n@prefix ore: <http://www.openarchives.org/ore/terms/>\n\n<> a pcdm:Object ;\nore:proxyFor </fcrepo/rest/objects/raven/> .' | curl -i -XPUT -H"Content-Type: text/turtle" http://localhost:8080/rest/collections/poe/members/ravenProxy --data-binary @-
```