### PR TITLE
Ensures that external resources are not exported by default.

### DIFF
--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -405,13 +405,14 @@ public class Exporter implements TransferProcess {
 
             //only retrieve content of external resources when retrieve external flag is enabled
             //otherwise write a zero length file.
-            final InputStream is = external && !config.retrieveExternal() ?
-                    IOUtils.toInputStream("", Charset.defaultCharset()) : response.getBody();
-            logger.info("Exporting binary: {}", uri);
-            writeResponse(uri, is, describedby, file);
-            writeHeadersFile(response, getHeadersFile(file));
-            exportLogger.info("export {} to {}", uri, file.getAbsolutePath());
-            successCount.incrementAndGet();
+            try (final InputStream is = external && !config.retrieveExternal() ?
+                    IOUtils.toInputStream("", Charset.defaultCharset()) : response.getBody()) {
+                logger.info("Exporting binary: {}", uri);
+                writeResponse(uri, is, describedby, file);
+                writeHeadersFile(response, getHeadersFile(file));
+                exportLogger.info("export {} to {}", uri, file.getAbsolutePath());
+                successCount.incrementAndGet();
+            }
 
         }
 

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -51,6 +51,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -388,7 +389,7 @@ public class Exporter implements TransferProcess {
             throws FcrepoOperationFailedException, IOException {
 
         if (!config.isIncludeBinaries()) {
-            logger.info("Skipping {}", uri);
+            logger.debug("Skipping: {} -> binaries are not included in this export configuration", uri);
             return;
         }
 
@@ -402,8 +403,12 @@ public class Exporter implements TransferProcess {
             final File file = external ? fileForExternalResources(uri, null, null, config.getBaseDirectory()) :
                     fileForBinary(uri, null, null, config.getBaseDirectory());
 
+            //only retrieve content of external resources when retrieve external flag is enabled
+            //otherwise write a zero length file.
+            final InputStream is = external && !config.retrieveExternal() ?
+                    IOUtils.toInputStream("", Charset.defaultCharset()) : response.getBody();
             logger.info("Exporting binary: {}", uri);
-            writeResponse(uri, response.getBody(), describedby, file);
+            writeResponse(uri, is, describedby, file);
             writeHeadersFile(response, getHeadersFile(file));
             exportLogger.info("export {} to {}", uri, file.getAbsolutePath());
             successCount.incrementAndGet();

--- a/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExporterTest.java
@@ -178,6 +178,7 @@ public class ExporterTest {
         bagArgs.setMode("export");
         bagArgs.setBaseDirectory(basedir);
         bagArgs.setIncludeBinaries(true);
+        bagArgs.setRetrieveExternal(true);
         bagArgs.setPredicates(predicates);
         bagArgs.setRdfLanguage("application/ld+json");
         bagArgs.setResource(resource3);
@@ -297,6 +298,7 @@ public class ExporterTest {
         config.setMode("export");
         config.setBaseDirectory(exportDirectory);
         config.setIncludeBinaries(true);
+        config.setRetrieveExternal(true);
         config.setPredicates(predicates);
         config.setRdfLanguage("application/ld+json");
         config.setResource(resource3);

--- a/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
@@ -177,6 +177,39 @@ public class ExporterIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testExportRetrieveExternalDisabled() throws Exception {
+        // Create an external content resource pointing at another repository resource
+        final URI binaryURI = URI.create(serverAddress + UUID.randomUUID());
+        createBody(binaryURI, "content", "text/plain");
+        final Map<String,String> headers = new HashMap<>();
+        headers.put("Link", "<" + binaryURI.toString() + ">;" +
+                "      rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; " +
+                "      handling=\"redirect\"; " +
+                "      type=\"text/plain\"");
+
+        createBody(url, new ByteArrayInputStream("".getBytes()), "text/plain", headers);
+
+        // Run an export process
+        final Config config = new Config();
+        config.setMode("export");
+        config.setBaseDirectory(TARGET_DIR);
+        config.setResource(url);
+        config.setIncludeBinaries(true);
+        config.setRetrieveExternal(false);
+        config.setUsername(USERNAME);
+        config.setPassword(PASSWORD);
+
+        final Exporter exporter = new Exporter(config, clientBuilder);
+        exporter.run();
+
+        // Verify
+        final File externalFile = new File(TARGET_DIR, url.getPath() + EXTERNAL_RESOURCE_EXTENSION);
+        assertTrue(externalFile.exists());
+        assertEquals("File length should be 0", 0, externalFile.length());
+
+    }
+
+    @Test
     public void testExportCustomPredicate() throws Exception {
         final String[] predicates = new String[]{ "http://example.org/custom" };
         final UUID uuid = UUID.randomUUID();

--- a/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/RoundtripIT.java
@@ -136,7 +136,7 @@ public class RoundtripIT extends AbstractResourceIT {
         final FcrepoResponse memento = post(timemapURI);
         assertEquals(SC_CREATED, memento.getStatusCode());
         final URI mementoURI = memento.getLocation();
-        roundtrip(uri, new ArrayList<URI>(), true, true, false);
+        roundtrip(uri, new ArrayList<URI>(), true, true, false, false);
         //timemap will be there because it is created automatically
         assertEquals(SC_OK, get(timemapURI).getStatusCode());
         //the memento however should not have been imported.
@@ -390,7 +390,7 @@ public class RoundtripIT extends AbstractResourceIT {
         assertTrue(exists(res1));
         assertTrue(exists(file1));
 
-        final Config config = roundtrip(res1, Collections.singletonList(file1), true, false, true);
+        final Config config = roundtrip(res1, Collections.singletonList(file1), true, false, true, false);
 
         // verify that files exist and contain expected content
         final File exportDir = config.getBaseDirectory();
@@ -498,7 +498,7 @@ public class RoundtripIT extends AbstractResourceIT {
 
         final String contentLength = get(file1).getHeaderValue("Content-Length");
         assertEquals("Unexpected Content-Length value", contentLength, binaryFileLength + "");
-        final Config config = roundtrip(URI.create(baseURI), true);
+        final Config config = roundtrip(URI.create(baseURI), true,true);
 
         // verify that files exist and contain expected content
         final File exportDir = config.getBaseDirectory();
@@ -648,12 +648,19 @@ public class RoundtripIT extends AbstractResourceIT {
         return createTypedLiteral(longString, XSDlong);
     }
 
-    private Config roundtrip(final URI uri, final boolean reset) throws FcrepoOperationFailedException {
-        return roundtrip(uri, new ArrayList<URI>(), true, true, true);
+    private Config roundtrip(final URI uri, final boolean reset)
+            throws FcrepoOperationFailedException {
+        return roundtrip(uri, new ArrayList<URI>(), true, true, true, false);
+    }
+
+    private Config roundtrip(final URI uri, final boolean reset, final boolean retrieveExternal)
+            throws FcrepoOperationFailedException {
+        return roundtrip(uri, new ArrayList<URI>(), true, true, true, retrieveExternal);
     }
 
     private Config roundtrip(final URI uri, final List<URI> relatedResources,
-            final boolean reset, final boolean includeBinary, final boolean includeVersions)
+            final boolean reset, final boolean includeBinary, final boolean includeVersions,
+                             final boolean retrieveExternal)
             throws FcrepoOperationFailedException {
         // export resources
         final Config config = new Config();
@@ -662,6 +669,7 @@ public class RoundtripIT extends AbstractResourceIT {
         config.setIncludeBinaries(includeBinary);
         config.setIncludeMembership(true);
         config.setResource(uri);
+        config.setRetrieveExternal(retrieveExternal);
         config.setPredicates(new String[]{ CONTAINS.toString() });
         config.setRdfExtension(DEFAULT_RDF_EXT);
         config.setRdfLanguage(DEFAULT_RDF_LANG);


### PR DESCRIPTION
Users must now specify --external=true to export proxied and redirected external resources.

Resolves: https://jira.lyrasis.org/browse/FCREPO-3416

This PR is covered by new integration test.

To test manually:
1. start up fcrepo 5.1.1 with allowed external content
```
cat "https://" > allowed_external_paths.txt
java -Dfcrepo.external.content.allowed=./allowed_external_paths.txt -jar fcrepo-webapp-5.1.1-jetty-console.jar --headless
```
2. create a proxied resource pointing at the newly created binary.
```
curl -i -H"Link: <https://wiki.lyrasis.org/download/attachments/4980737/atl.site.logo>; rel=\"http://fedoraent\"; handling=\"proxy\"; type=\"image/png\"" -XPUT -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/proxy_test
```
4. perform an export
```
 java -jar fcrepo-import-export-1.1.0-SNAPSHOT.jar -b -d export-3416 -u fedoraAdmin:fedoraAdmin  -b -m export -r http://localhost:8080/rest
```
5. verify that the external resource file is zero length
```
ls -lastR export-3416/ | grep proxy_test.external
```
6. perform export again with --external flag enabled
```
# remove previous export
 rm -rf export-3416
# run export
 java -jar target/fcrepo-import-export-1.1.0-SNAPSHOT.jar -b -d export-3416 -u fedoraAdmin:fedoraAdmin  -b --external -m export -r http://localhost:8080/rest
```
7. verify that the external resource non-zero length.
```
ls -lastR export-3416/ | grep proxy_test.external
```