### PR TITLE
parallelized export; added resume file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,62 +32,80 @@ INFO 15:15:10.091 (Exporter) Running exporter...
 The following CLI options for the import/export utility are available:
 
 ```
-Usage: fcrepo-import-export [-abhiLtVx] [--acls] [--membership]
-                            [--bag-algorithms=<algorithms>] [-d=<dir>] [-g=<profile>] 
-                            [-G=<path>] [-l=<rdfLang>] -m=<mode> [-M=<map>]  
-                            [-p=<predicates>] -r=<resource> [-R=<uri>] [-s=<format>] 
-                            [-u=<user>] [-w=<writeConfig>]
-       
-  -a,--auditLog     Enable audit log creation, disabled by default
-  --acls            When present this flag indicates that acls should be imported/exported.
-  -b,--binaries     When present this flag indicates that binaries should be imported/exported.
-  --bag-algorithms <algorithms>    
-                    Comma separated list of algorithms to use when creating a BagIt export
-    -d,--dir <dir>                      
-                    The directory to export repo to or import the repo from.
-    -g,--bag-profile <profile>          
-                    Export and import BagIt bags using profile
-                      [default|aptrust|metaarchive|perseids|beyondtherepository]
-    -G,--bag-config <path>              
-                    Path to the bag config file
-    -h,--help       Print these options
-    -i,--inbound    When present this flag indicates that inbound references should be exported.
-    -L,--legacyMode   
-                    When importing, omit certain server-managed-triples that aren't
-                      modifiable in old versions of fedora.
-    -l,--rdfLang <rdfLang>              
-                    RDF language 
-                      Default: text/turtle
-    -m,--mode <mode>                    
-                    Mode: [import|export]
-    -M,--map <map>                      
-                    Old and new base URIs, separated by comma, to map URIs when importing
-    --membership    When present this flag indicates that membership references should be exported.
-    -p,--predicates <predicates>        
-                    Comma-separated list of predicates to define resource containment
-    -r,--resource <resource>            
-                    Resource (URI) to import/export
-    -R,--repositoryRoot <uri>           
-                    When exporting, use this URI as the repository root; if not given, 
-                      export will attempt to automatically determine the repository root
-    -s,--bag-serialization <format>     
-                    Export BagIt bags into a serialized format. Available formats depend on the
-                      bag profile specified.
-                      aptrust: [tar]
-                      beyondtherepository: [zip, tar, gzip]
-                      fedora-import-export: [tar]
-                      metaarchive: [tar]
-                      perseids: [zip, tar]
-    -t,--overwriteTombstones            
-                    When importing, overwrite "tombstones" left behind after resources 
-                      were deleted.
-    -u,--user <user>                    
-                    username:password for fedora basic authentication
-    -V,--versions   When exporting, include versions of resources and binaries.
-    -w,--writeConfig <writeConfig>      
-                    When present this flag indicates that a sample config should be written 
-                      at the specified filename.
-    -x,--external   When present this flag indicates that external content should be exported.
+Running Import/Export Utility from command line arguments
+usage: java -jar import-export-driver.jar [-a] [--acls] [-b] [--bag-algorithms
+       <algorithms>] -d <dir> [-f <path>] [-g <profile>] [-G <path>] [-h] [-i]
+       [-L] [-l <rdfLang>] -m <mode> [-M <map>] [--membership] [-p <predicates>]
+       [-r <resource>] [-R <uri>] [-s <format>] [-t] [-T <num>] [-u <user>] [-V]
+       [-w <writeConfig>] [-x]
+    -a,--auditLog                       Enable audit log creation, disabled by
+                                        default
+       --acls                           When present this flag indicates that
+                                        acls should be imported/exported.
+    -b,--binaries                       When present this flag indicates that
+                                        binaries should be imported/exported.
+       --bag-algorithms <algorithms>    Comma separated list of algorithms to
+                                        use when creating a BagIt export
+    -d,--dir <dir>                      The directory to export repo to or
+                                        import the repo from.
+    -f,--resourcesFile <path>           Path to a file that contains a list of
+                                        resources to export
+    -g,--bag-profile <profile>          Export and import BagIt bags using
+                                        profile
+                                        [default|aptrust|metaarchive|perseids|
+                                        beyondtherepository]
+    -G,--bag-config <path>              Path to the bag config file
+    -h,--help                           Print these options
+    -i,--inbound                        When present this flag indicates that
+                                        inbound references should be exported.
+    -L,--legacyMode                     When importing, omit certain
+                                        server-managed-triples that aren't
+                                        modifiable in old versions of fedora.
+    -l,--rdfLang <rdfLang>              RDF language (default: text/turtle)
+    -m,--mode <mode>                    Mode: [import|export]
+    -M,--map <map>                      Old and new base URIs, separated by
+                                        comma, to map URIs when importing
+       --membership                     When present this flag indicates that
+                                        membership references should be
+                                        exported.
+    -p,--predicates <predicates>        Comma-separated list of predicates to
+                                        define resource containment
+    -r,--resource <resource>            Resource (URI) to import/export
+    -R,--repositoryRoot <uri>           When exporting, use this URI as the
+                                        repository root; if not given, export
+                                        will attempt to automatically determine
+                                        the repository root
+    -s,--bag-serialization <format>     Export BagIt bags into a serialized
+                                        format. Available formats depend on the
+                                        bag profile specified.
+                                        aptrust: [tar]
+                                        beyondtherepository: [zip, tar, gzip]
+                                        fedora-import-export: [tar]
+                                        metaarchive: [tar]
+                                        perseids: [zip, tar]
+    -t,--overwriteTombstones            When importing, overwrite "tombstones"
+                                        left behind after resources were
+                                        deleted.
+    -T,--threadCount <num>              Specifies the number of threads to use
+                                        when exporting resources. By default,
+                                        one less than the number of available
+                                        processors will be used.
+    -u,--user <user>                    username:password for fedora basic
+                                        authentication
+    -V,--versions                       When exporting, include versions of
+                                        resources and binaries.
+    -w,--writeConfig <writeConfig>      When present this flag indicates that a
+                                        sample config should be written at the
+                                        specified filename.
+    -x,--external                       When present this flag indicates that
+                                        external content should be exported.
+
+--- or ---
+
+Running Import/Export Utility from configuration file
+usage: java -jar import-export-driver.jar -c <config> [-u <user>]
+    -c,--config <config>    Path to config file
+    -u,--user <user>        username:password for fedora basic authentication
  ```
 
 
@@ -163,6 +181,22 @@ If running against a version of fedora in which fedora:lastModified, fedora:last
 java -jar fcrepo-import-export.jar --mode import --resource http://example.org:8080/fedora/rest/ --dir /tmp/test --binaries --legacyMode
 ```
 
+Resuming an Export
+------------------
+
+If an export is interrupted or a subset of resources fail to export, then a log file named `remaining_TIMESTAMP.log` is
+created that contains the URIs of the resources that were not exported. The export can be resumed by passing this file
+back to the utility on a subsequent run. For example:
+
+```shell
+java -jar fcrepo-import-export.jar
+  --dir my-5.1.1-export \
+  --user fedoraAdmin:fedoraAdmin \
+  --mode export \
+  --repositoryRoot http://localhost:8080/rest \
+  --resourcesFile remaining_TIMESTAMP.log \
+  --binaries --versions
+```
 
 Running the import/export utility with BagIt support
 ------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
             <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
             <project.build.directory>${project.build.directory}</project.build.directory>
             <fcrepo.dynamic.tomcat.ajp.port>${fcrepo.dynamic.tomcat.ajp.port}</fcrepo.dynamic.tomcat.ajp.port>
+            <fcrepo.log.importexport.logdir>${project.build.directory}</fcrepo.log.importexport.logdir>
           </systemPropertyVariables>
         </configuration>
         <executions>
@@ -277,6 +278,7 @@
               <fcrepo.spring.eventing.configuration>file:${project.basedir}/src/test/resources/spring-test/noop.xml</fcrepo.spring.eventing.configuration>
               <fcrepo.spring.jms.configuration>file:${project.basedir}/src/test/resources/spring-test/noop.xml</fcrepo.spring.jms.configuration>
               <fcrepo.spring.transactions.configuration>file:${project.basedir}/src/test/resources/spring-test/noop.xml</fcrepo.spring.transactions.configuration>
+              <fcrepo.log.importexport.logdir>${project.build.directory}</fcrepo.log.importexport.logdir>
             </systemProperties>
           </container>
           <configuration>

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -76,6 +77,9 @@ public class Config {
     private String rdfLanguage = DEFAULT_RDF_LANG;
     private String username;
     private String password;
+
+    private Integer threadCount;
+    private Path resourceFile;
 
     private boolean auditLog = false;
 
@@ -596,6 +600,12 @@ public class Config {
         final String predicates = String.join(",", this.getPredicates());
         map.put("predicates", predicates);
         map.put("auditLog", Boolean.toString(this.auditLog));
+        if (threadCount != null) {
+            map.put("threadCount", threadCount.toString());
+        }
+        if (resourceFile != null) {
+            map.put("resourceFile", resourceFile.toAbsolutePath().toString());
+        }
         return map;
     }
 
@@ -656,5 +666,39 @@ public class Config {
      */
     public void setIncludeAcls(final boolean includeAcls) {
         this.includeAcls = includeAcls;
+    }
+
+    /**
+     * @return the number of threads to use, may be null
+     */
+    public Integer getThreadCount() {
+        return threadCount;
+    }
+
+    /**
+     * Set the number of threads to use, must be at least 1
+     *
+     * @param threadCount the number of threads to use
+     */
+    public void setThreadCount(final Integer threadCount) {
+        if (threadCount == null) {
+            this.threadCount = threadCount;
+        } else {
+            this.threadCount = Math.max(threadCount, 1);
+        }
+    }
+
+    /**
+     * @return the path to the file that contains resource uris to process
+     */
+    public Path getResourceFile() {
+        return resourceFile;
+    }
+
+    /**
+     * @param resourceFile the path to the file that contains resource uris to process
+     */
+    public void setResourceFile(final Path resourceFile) {
+        this.resourceFile = resourceFile;
     }
 }

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -676,15 +676,16 @@ public class Config {
     }
 
     /**
-     * Set the number of threads to use, must be at least 1
+     * Set the number of threads to use. If null, then the number of threads will be defaulted
+     * based on the number of available processors.
      *
-     * @param threadCount the number of threads to use
+     * @param threadCount the number of threads to use, or null
      */
     public void setThreadCount(final Integer threadCount) {
-        if (threadCount == null) {
-            this.threadCount = threadCount;
+        if (threadCount == null || threadCount < 1) {
+            this.threadCount = null;
         } else {
-            this.threadCount = Math.max(threadCount, 1);
+            this.threadCount = threadCount;
         }
     }
 

--- a/src/main/java/org/fcrepo/importexport/common/ResourceFileParser.java
+++ b/src/main/java/org/fcrepo/importexport/common/ResourceFileParser.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.importexport.common;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parses a file that contains a single URI per line
+ *
+ * @author pwinckles
+ */
+public final class ResourceFileParser {
+
+    private ResourceFileParser() {
+        // static class
+    }
+
+    /**
+     * Parses a file that contains a single URI per line and returns a list of all of the URIs
+     *
+     * @param path path to the file
+     * @return list of URIs
+     */
+    public static List<URI> parse(final Path path) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(path)))) {
+            final List<URI> uris = new ArrayList<>();
+            while (reader.ready()) {
+                uris.add(URI.create(reader.readLine()));
+            }
+            return uris;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+}

--- a/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
+++ b/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
@@ -45,6 +45,7 @@ import org.fcrepo.importexport.patch.RdfWriterHelper;
 public interface TransferProcess {
 
     final static String IMPORT_EXPORT_LOG_PREFIX = "org.fcrepo.importexport.audit";
+    final static String REMAINING_LOG_PREFIX = "org.fcrepo.importexport.remaining";
     final static String BAGIT_CHECKSUM_DELIMITER = "  ";
 
     // Used only to load patched RDF writers

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -18,6 +18,7 @@
 package org.fcrepo.importexport.exporter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
@@ -39,9 +40,11 @@ import org.fcrepo.client.FcrepoResponse;
 import org.fcrepo.client.GetBuilder;
 import org.fcrepo.client.HeadBuilder;
 import org.fcrepo.importexport.common.Config;
+import org.fcrepo.importexport.common.ResourceFileParser;
 import org.fcrepo.importexport.common.TransferProcess;
 import org.slf4j.Logger;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -51,12 +54,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -67,10 +72,17 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.codec.binary.Hex.encodeHex;
 import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
@@ -107,28 +119,28 @@ public class Exporter implements TransferProcess {
 
     private static final Logger logger = getLogger(Exporter.class);
 
-    private Config config;
+    private final Config config;
     protected FcrepoClient.FcrepoClientBuilder clientBuilder;
-    private URI binaryURI;
-    private URI containerURI;
-    private URI rdfSourceURI;
+    private final URI binaryURI;
+    private final URI containerURI;
+    private final URI rdfSourceURI;
     private BagWriter bag;
     private BagSerializer bagSerializer;
     private String bagProfileId;
-    private MessageDigest sha1 = null;
-    private MessageDigest sha256 = null;
-    private MessageDigest sha512 = null;
-    private MessageDigest md5 = null;
     private HashMap<File, String> sha1FileMap = null;
     private HashMap<File, String> sha256FileMap = null;
     private HashMap<File, String> sha512FileMap = null;
     private HashMap<File, String> md5FileMap = null;
 
-    private Logger exportLogger;
-    private SimpleDateFormat dateFormat;
-    private AtomicLong successCount = new AtomicLong(); // set to zero at start
-    private AtomicLong successBytes = new AtomicLong();
+    private final Logger exportLogger;
+    private final Logger remainingLogger;
+
+    private final SimpleDateFormat dateFormat;
+    private final AtomicLong successCount = new AtomicLong(); // set to zero at start
+    private final AtomicLong successBytes = new AtomicLong();
     protected URI repositoryRoot = null;
+
+    private final TaskManager taskManager;
 
     /**
      * Constructor that takes the Import/Export configuration
@@ -143,8 +155,10 @@ public class Exporter implements TransferProcess {
         this.containerURI = URI.create(CONTAINER.getURI());
         this.rdfSourceURI = URI.create(RDF_SOURCE.getURI());
         this.exportLogger = config.getAuditLog();
+        this.remainingLogger = getLogger(REMAINING_LOG_PREFIX);
         this.dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         this.repositoryRoot = config.getRepositoryRoot();
+        this.taskManager = new TaskManager(config.getThreadCount());
 
         if (config.getBagProfile() != null) {
             configureBagItParameters();
@@ -239,19 +253,15 @@ public class Exporter implements TransferProcess {
     private void setupFileMap(final BagItDigest digest) {
         switch (digest) {
             case MD5:
-                this.md5 = digest.messageDigest();
                 this.md5FileMap = new HashMap<>();
                 break;
             case SHA1:
-                this.sha1 = digest.messageDigest();
                 this.sha1FileMap = new HashMap<>();
                 break;
             case SHA256:
-                this.sha256 = digest.messageDigest();
                 this.sha256FileMap = new HashMap<>();
                 break;
             case SHA512:
-                this.sha512 = digest.messageDigest();
                 this.sha512FileMap = new HashMap<>();
                 break;
             default:
@@ -298,21 +308,39 @@ public class Exporter implements TransferProcess {
         }
         logger.debug("Repository root is " + repositoryRoot);
 
-        export(config.getResource());
+        if (config.getResource() != null) {
+            export(config.getResource());
+        }
+
+        if (config.getResourceFile() != null) {
+            logger.info("Loading resources to export from file {}", config.getResourceFile());
+            ResourceFileParser.parse(config.getResourceFile()).forEach(this::export);
+        }
+
+        try {
+            taskManager.awaitCompletion();
+            logger.info("Export complete");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } finally {
+            taskManager.shutdown();
+        }
+
         if (bag != null) {
             try {
                 logger.info("Finishing bag manifests...");
                 bag.addTags(BagConfig.BAG_INFO_KEY, bagTechMetadata());
-                if (sha1 != null) {
+                if (sha1FileMap != null) {
                     bag.registerChecksums(BagItDigest.SHA1, sha1FileMap);
                 }
-                if (sha256 != null) {
+                if (sha256FileMap != null) {
                     bag.registerChecksums(BagItDigest.SHA256, sha256FileMap);
                 }
-                if (sha512 != null) {
+                if (sha512FileMap != null) {
                     bag.registerChecksums(BagItDigest.SHA512, sha512FileMap);
                 }
-                if (md5 != null) {
+                if (md5FileMap != null) {
                     bag.registerChecksums(BagItDigest.MD5, md5FileMap);
                 }
                 bag.write();
@@ -340,7 +368,23 @@ public class Exporter implements TransferProcess {
         return metadata;
     }
 
+    /**
+     * Queues a new resource to be exported
+     *
+     * @param uri resource to export
+     */
     private void export(final URI uri) {
+        taskManager.submit(uri);
+    }
+
+    /**
+     * This does the actual work of exporting a resource. It should only be called from a export task.
+     *
+     * @param uri resource to export
+     * @throws FcrepoOperationFailedException
+     * @throws IOException
+     */
+    private void doExport(final URI uri) throws FcrepoOperationFailedException, IOException {
         logger.trace("HEAD " + uri);
         try (FcrepoResponse response = client().head(uri).disableRedirects().perform()) {
             if (response.getStatusCode() == 404 && uri.toString().endsWith("fcr:acl")) {
@@ -373,17 +417,6 @@ public class Exporter implements TransferProcess {
             if (acl != null && config.isIncludeAcls()) {
                 export(acl);
             }
-
-
-        } catch (FcrepoOperationFailedException ex) {
-            logger.warn("Error retrieving content: {}", ex.toString());
-            exportLogger.error(String.format("Error retrieving context of uri: %1$s, Message: %2$s",
-                    uri, ex.toString()),
-                ex);
-        } catch (IOException ex) {
-            logger.warn("Error writing content: {}", ex.toString());
-            exportLogger.error(String.format("Error writing content from uri: %1$s, Message: %2$s", uri, ex.toString()),
-                ex);
         }
     }
 
@@ -435,13 +468,9 @@ public class Exporter implements TransferProcess {
         }
     }
 
-    private void exportRdf(final URI uri, final URI binaryURI)
-            throws FcrepoOperationFailedException {
+    private void exportRdf(final URI uri, final URI binaryURI) throws FcrepoOperationFailedException, IOException {
         final File file = fileForURI(uri, null, null, config.getBaseDirectory(), config.getRdfExtension());
-        if (file == null) {
-            logger.info("Skipping {}", uri);
-            return;
-        } else if (file.exists()) {
+        if (file.exists()) {
             logger.info("Already exported {}", uri);
             return;
         }
@@ -460,14 +489,16 @@ public class Exporter implements TransferProcess {
 
         getBuilder.preferRepresentation(includeUris, omitUris);
 
+        Model model = null;
+        Set<URI> inboundMembers = null;
+
         try (FcrepoResponse response = getBuilder.perform()) {
             checkValidResponse(response, uri, config.getUsername());
             logger.info("Exporting rdf: {}", uri);
 
             final String responseBody = IOUtils.toString(response.getBody(), StandardCharsets.UTF_8);
-            final Model model = createDefaultModel().read(new ByteArrayInputStream(responseBody.getBytes()),
+            model = createDefaultModel().read(new ByteArrayInputStream(responseBody.getBytes()),
                     null, config.getRdfLanguage());
-            Set<URI> inboundMembers = null;
 
             if (!config.isIncludeBinaries() || config.retrieveInbound()) {
 
@@ -494,15 +525,20 @@ public class Exporter implements TransferProcess {
 
             exportLogger.info("export {} to {}", uri, file.getAbsolutePath());
             successCount.incrementAndGet();
-
-            exportMembers(model, inboundMembers);
-            exportVersions(uri);
-        } catch ( Exception ex ) {
-            ex.printStackTrace();
-            exportLogger.error(String.format("Error exporting description: %1$s, Cause: %2$s",
-                    uri, ex.getMessage()), ex);
+        } catch (RuntimeException | FcrepoOperationFailedException | IOException e) {
+            // Cleanup a partially exported resource so that it can be retried
+            try {
+                Files.deleteIfExists(file.toPath());
+            } catch (Exception e2) {
+                logger.warn("Failed to cleanup partially exported resource {}: {}", uri, e2.getMessage());
+                exportLogger.error(String.format("Failed to cleanup partially exported resource : %1$s, Message: %2$s",
+                        uri, e2), e2);
+            }
+            throw e;
         }
 
+        exportMembers(model, inboundMembers);
+        exportVersions(uri);
     }
 
     private File getHeadersFile(final File file) {
@@ -514,21 +550,7 @@ public class Exporter implements TransferProcess {
         if (!headers.isEmpty()) {
             final String json = new ObjectMapper().writeValueAsString(headers);
             final InputStream byteInputStream = new ByteArrayInputStream(json.getBytes());
-            try (OutputStream headerOut = Files.newOutputStream(file.toPath())) {
-                copy(byteInputStream, headerOut);
-                if (md5FileMap != null) {
-                    md5FileMap.put(file, new String(encodeHex(md5.digest())));
-                }
-                if (sha1FileMap != null) {
-                    sha1FileMap.put(file, new String(encodeHex(sha1.digest())));
-                }
-                if (sha256FileMap != null) {
-                    sha256FileMap.put(file, new String(encodeHex(sha256.digest())));
-                }
-                if (sha512FileMap != null) {
-                    sha512FileMap.put(file, new String(encodeHex(sha512.digest())));
-                }
-            }
+            copy(byteInputStream, file);
         }
     }
 
@@ -640,7 +662,7 @@ public class Exporter implements TransferProcess {
 
             timemapURI = response.getLinkHeaders("timemap").stream().findFirst().orElse(null);
             if (timemapURI == null) {
-                logger.trace("Resource {} is not versioned:  no rel=\"timemap\" Link header present on {}", uri);
+                logger.trace("Resource {} is not versioned:  no rel=\"timemap\" Link header present", uri);
                 return;
             }
         }
@@ -685,23 +707,8 @@ public class Exporter implements TransferProcess {
         if (!file.getParentFile().exists()) {
             file.getParentFile().mkdirs();
         }
-        try (OutputStream out = new FileOutputStream(file)) {
-            copy(in, out);
-            logger.info("Exported {} to {}", uri, file.getAbsolutePath());
-
-            if (md5FileMap != null) {
-                md5FileMap.put(file, new String(encodeHex(md5.digest())));
-            }
-            if (sha1FileMap != null) {
-                sha1FileMap.put(file, new String(encodeHex(sha1.digest())));
-            }
-            if (sha256FileMap != null) {
-                sha256FileMap.put(file, new String(encodeHex(sha256.digest())));
-            }
-            if (sha512FileMap != null) {
-                sha512FileMap.put(file, new String(encodeHex(sha512.digest())));
-            }
-        }
+        copy(in, file);
+        logger.info("Exported {} to {}", uri, file.getAbsolutePath());
 
         if (describedby != null) {
             for (final Iterator<URI> it = describedby.iterator(); it.hasNext(); ) {
@@ -713,42 +720,190 @@ public class Exporter implements TransferProcess {
     /**
      * Copy bytes and generate checksums
      * @param in Source data
-     * @param out Data destination
+     * @param file destination
      * @throws IOException If an I/O error occurs
      */
-    private void copy(final InputStream in, final OutputStream out) throws IOException {
-        if (md5 != null) {
-            md5.reset();
+    private void copy(final InputStream in, final File file) throws IOException {
+        final MessageDigest md5 = md5FileMap == null ? null : BagItDigest.MD5.messageDigest();
+        final MessageDigest sha1 = sha1FileMap == null ? null : BagItDigest.SHA1.messageDigest();
+        final MessageDigest sha256 = sha256FileMap == null ? null : BagItDigest.SHA256.messageDigest();
+        final MessageDigest sha512 = sha512FileMap == null ? null : BagItDigest.SHA512.messageDigest();
+
+        final InputStream wrappedStream = wrap(wrap(wrap(wrap(in, md5), sha1), sha256), sha512);
+
+        try (final OutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
+            final int bytes = IOUtils.copy(wrappedStream, out);
+            successBytes.addAndGet(bytes);
+            if (md5FileMap != null) {
+                md5FileMap.put(file, Hex.encodeHexString(md5.digest()));
+            }
+            if (sha1FileMap != null) {
+                sha1FileMap.put(file, Hex.encodeHexString(sha1.digest()));
+            }
+            if (sha256FileMap != null) {
+                sha256FileMap.put(file, Hex.encodeHexString(sha256.digest()));
+            }
+            if (sha512FileMap != null) {
+                sha512FileMap.put(file, Hex.encodeHexString(sha512.digest()));
+            }
         }
-        if (sha1 != null) {
-            sha1.reset();
+    }
+
+    private InputStream wrap(final InputStream in, final MessageDigest digest) {
+        if (digest != null) {
+            return new DigestInputStream(in, digest);
         }
-        if (sha256 != null) {
-            sha256.reset();
-        }
-        if (sha512 != null) {
-            sha512.reset();
+        return in;
+    }
+
+    private class TaskManager {
+
+        private final ExecutorService executorService;
+        private final BlockingQueue<Runnable> workQueue;
+        private final AtomicLong count;
+        private final Object lock;
+        private boolean shutdown = false;
+
+        /**
+         * Creates a new task manager that uses the specified number of threads
+         *
+         * @param threadCount the number of threads to use, may be null to use default
+         */
+        public TaskManager(final Integer threadCount) {
+            final int threads = Math.max(threadCount == null
+                    ? Runtime.getRuntime().availableProcessors() - 1 : threadCount, 1);
+
+            logger.info("Using {} threads to export resources", threads);
+
+            this.workQueue = new LinkedBlockingQueue<>();
+            this.executorService = new ThreadPoolExecutor(threads, threads,
+                    0L, TimeUnit.MILLISECONDS,
+                    workQueue);
+            this.count = new AtomicLong(0);
+            this.lock = new Object();
+
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                if (!shutdown) {
+                    logger.info("Shutting down...");
+                    shutdown();
+                }
+            }));
         }
 
-        int read = 0;
-        final byte[] buf = new byte[8192];
-        while ((read = in.read(buf)) != -1) {
-            if (md5 != null) {
-                md5.update(buf, 0, read);
+        /**
+         * Submits a new resource to be exported
+         *
+         * @param uri the uri of the resource to export
+         */
+        public void submit(final URI uri) {
+            try {
+                executorService.submit(new ExportTask(uri, () -> {
+                    try {
+                        Exporter.this.doExport(uri);
+                    } catch (Exception e) {
+                        remainingLogger.info("{}", uri);
+
+                        if (e instanceof FcrepoOperationFailedException) {
+                            logger.warn("Error retrieving content: {}", e.toString());
+                            exportLogger.error(String.format("Error retrieving context of uri: %1$s, Message: %2$s",
+                                    uri, e), e);
+                        } else if (e instanceof IOException) {
+                            logger.warn("Error writing content: {}", e.toString());
+                            exportLogger.error(String.format("Error writing content from uri: %1$s, Message: %2$s",
+                                    uri, e), e);
+                        } else {
+                            logger.warn("Error exporting content: {}", e.toString());
+                            exportLogger.error(String.format("Error exporting content from uri: %1$s, Message: %2$s",
+                                    uri, e), e);
+                        }
+                    } finally {
+                        count.decrementAndGet();
+                        synchronized (lock) {
+                            lock.notifyAll();
+                        }
+                    }
+                }));
+            } catch (RejectedExecutionException e) {
+                remainingLogger.info("{}", uri);
             }
-            if (sha1 != null) {
-                sha1.update(buf, 0, read);
+
+            count.incrementAndGet();
+        }
+
+        /**
+         * Waits for all resources to be exported
+         *
+         * @throws InterruptedException
+         */
+        public void awaitCompletion() throws InterruptedException {
+            if (count.get() == 0) {
+                return;
             }
-            if (sha256 != null) {
-                sha256.update(buf, 0, read);
+
+            synchronized (lock) {
+                while (count.get() > 0) {
+                    lock.wait();
+                }
             }
-            if (sha512 != null) {
-                sha512.update(buf, 0, read);
+        }
+
+        /**
+         * Shutsdown the executor service, drains all remaining tasks to the log, and waits for the in progress
+         * tasks to complete.
+         */
+        public synchronized void shutdown() {
+            if (!shutdown) {
+                shutdown = true;
+
+                try {
+                    executorService.shutdown();
+                    drainTasks();
+                    logger.info("Waiting for inflight tasks to complete...");
+                    if (!executorService.awaitTermination(5, TimeUnit.MINUTES)) {
+                        logger.warn("Failed to shutdown executor service cleanly after 1 minute of waiting");
+                        executorService.shutdownNow();
+                    }
+                } catch (InterruptedException e) {
+                    logger.warn("Failed to shutdown executor service cleanly");
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
             }
-            if (out != null) {
-                out.write(buf, 0, read);
-                successBytes.addAndGet(read);
-            }
+        }
+
+        /**
+         * Empties the queue of unprocessed tasks and adds them to the remaining log
+         */
+        private void drainTasks() {
+            final List<Runnable> remaining = new ArrayList<>(workQueue.size());
+            workQueue.drainTo(remaining);
+            remaining.forEach(task -> {
+                try {
+                    // Dirty hack to get original callable
+                    final Field field = FutureTask.class.getDeclaredField("callable");
+                    field.setAccessible(true);
+                    final ExportTask inner = (ExportTask) field.get(task);
+                    remainingLogger.info("{}", inner.uri);
+                } catch (Exception e) {
+                    logger.warn("Failed to extract unprocessed resource URI", e);
+                }
+            });
+        }
+    }
+
+    private static class ExportTask implements Callable<Void> {
+        private final URI uri;
+        private final Runnable runnable;
+
+        private ExportTask(final URI uri, final Runnable runnable) {
+            this.uri = uri;
+            this.runnable = runnable;
+        }
+
+        @Override
+        public Void call() {
+            runnable.run();
+            return null;
         }
     }
 }

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -879,7 +879,7 @@ public class Exporter implements TransferProcess {
                     drainTasks();
                     logger.info("Waiting for inflight tasks to complete...");
                     if (!executorService.awaitTermination(5, TimeUnit.MINUTES)) {
-                        logger.warn("Failed to shutdown executor service cleanly after 1 minute of waiting");
+                        logger.warn("Failed to shutdown executor service cleanly after 5 minute of waiting");
                         executorService.shutdownNow();
                     }
                 } catch (InterruptedException e) {

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -801,7 +801,7 @@ public class Exporter implements TransferProcess {
                     try {
                         Exporter.this.doExport(uri);
                     } catch (Exception e) {
-                        remainingLogger.info("{}", uri);
+                        remainingLogger.error("{}", uri);
 
                         if (e instanceof FcrepoOperationFailedException) {
                             logger.warn("Error retrieving content: {}", e.toString());
@@ -824,7 +824,7 @@ public class Exporter implements TransferProcess {
                     }
                 }));
             } catch (RejectedExecutionException e) {
-                remainingLogger.info("{}", uri);
+                remainingLogger.error("{}", uri);
             }
 
             count.incrementAndGet();
@@ -883,7 +883,7 @@ public class Exporter implements TransferProcess {
                     final Field field = FutureTask.class.getDeclaredField("callable");
                     field.setAccessible(true);
                     final ExportTask inner = (ExportTask) field.get(task);
-                    remainingLogger.info("{}", inner.uri);
+                    remainingLogger.error("{}", inner.uri);
                 } catch (Exception e) {
                     logger.warn("Failed to extract unprocessed resource URI", e);
                 }

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -879,7 +879,7 @@ public class Exporter implements TransferProcess {
                     drainTasks();
                     logger.info("Waiting for inflight tasks to complete...");
                     if (!executorService.awaitTermination(5, TimeUnit.MINUTES)) {
-                        logger.warn("Failed to shutdown executor service cleanly after 5 minute of waiting");
+                        logger.warn("Failed to shutdown executor service cleanly after 5 minutes of waiting");
                         executorService.shutdownNow();
                     }
                 } catch (InterruptedException e) {

--- a/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/Exporter.java
@@ -762,7 +762,7 @@ public class Exporter implements TransferProcess {
             final long bytes = successBytes.get();
             final long count = successCount.get();
             final Duration duration = Duration.between(startTime, Instant.now());
-            final long rate = bytes / Math.min(duration.toMillis() / 1000, 1);
+            final long rate = bytes / Math.max(duration.toMillis() / 1000, 1);
 
             logger.info("Progress report: Exported {} resources in {} at {} bytes/sec", count, duration, rate);
         }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,6 +8,7 @@
   </appender>
 
   <timestamp key="bySecond" datePattern="yyyyMMdd'T'HHmmss"/>
+
   <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
     <discriminator>
         <Key>defaultKey</Key>
@@ -26,6 +27,26 @@
     </sift>
   </appender>
 
+  <!-- This appender is used to create a file that contains URIs of resources that were not exported
+       either due to failure or early termination -->
+  <appender name="REMAINING" class="ch.qos.logback.classic.sift.SiftingAppender">
+    <discriminator>
+      <Key>defaultKey</Key>
+      <defaultValue>defaultValue</defaultValue>
+    </discriminator>
+    <sift>
+    <appender name="REMAINING-INNER" class="ch.qos.logback.core.FileAppender">
+        <!-- use the previously created timestamp to create a uniquely
+          named log file -->
+        <file>${fcrepo.log.importexport.logdir:-${PWD}}/remaining_${bySecond}.log</file>
+        <prudent>true</prudent>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+    </sift>
+  </appender>
+
   <logger name="org.fcrepo.importexport.exporter" additivity="false" level="${fcrepo.log.exporter:-null}">
     <appender-ref ref="STDOUT"/>
   </logger>
@@ -40,6 +61,9 @@
   </logger>
   <logger name="org.fcrepo.importexport.audit" additivity="false" level="${fcrepo.log.importexport.audit:-INFO}">
     <appender-ref ref="SIFT"/>
+  </logger>
+  <logger name="org.fcrepo.importexport.remaining" additivity="false" level="INFO">
+    <appender-ref ref="REMAINING"/>
   </logger>
   <root level="WARN">
     <appender-ref ref="STDOUT"/>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,6 +7,20 @@
     </encoder>
   </appender>
 
+  <timestamp key="bySecond" datePattern="yyyyMMdd'T'HHmmss"/>
+
+  <!-- This appender is used to create a file that contains URIs of resources that were not exported
+     either due to failure or early termination -->
+  <appender name="REMAINING" class="ch.qos.logback.core.FileAppender">
+    <!-- use the previously created timestamp to create a uniquely
+      named log file -->
+    <file>target/remaining_${bySecond}.log</file>
+    <prudent>true</prudent>
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
+
   <logger name="org.fcrepo.importexport" additivity="false" level="${fcrepo.importexport.log:-DEBUG}">
     <appender-ref ref="STDOUT"/>
   </logger>
@@ -18,6 +32,9 @@
   </logger>
   <logger name="org.glassfish" additivity="false" level="ERROR">
     <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.importexport.remaining" additivity="false" level="INFO">
+    <appender-ref ref="REMAINING"/>
   </logger>
   <root additivity="false" level="WARN">
     <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
**Jira**: https://fedora-repository.atlassian.net/browse/FCREPO-3742

### What this does

1. Parallelizes the export code
2. Creates a new file that captures resource URIs that either failed to be processed or where waiting to be processed when the application was killed
3. Allows exports to use the file created in step 2 to resume a failed export
4. Adds a periodic progress report, every 10,000 resources, like the following: `INFO 11:42:44.067 (Exporter) Progress report: Exported 520 resources in PT19.126342S at 1600461 bytes/sec`

### How should this be tested

1. Setup a F5 instance with data
2. Run the exporter as follows: `java -jar fcrepo-import-export-1.1.0-SNAPSHOT.jar -b --dir my-5.1.1-export --user fedoraAdmin:fedoraAdmin --mode export --repositoryRoot http://localhost:8080/rest --resource http://localhost:8080/rest --binaries --versions`
3. Kill (ctrl+c) the utility while it's still exporting
4. See the `remaining_TIMESTAMP.log` file in the current directory containing the URIs of the resources that were waiting to be exported when the export was killed
5. Run the exporter again as follows: `java -jar fcrepo-import-export-1.1.0-SNAPSHOT.jar -b --dir my-5.1.1-export --user fedoraAdmin:fedoraAdmin --mode export --repositoryRoot http://localhost:8080/rest --resourcesFile remaining_TIMESTAMP.log --binaries --versions`
6. See the exporter pick up where it left off

Additionally, the number of threads the exporter used can be adjusted using the `-T` option.