### PR TITLE
Allow tombstones to be skipped on export

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Running Import/Export Utility from command line arguments
 usage: java -jar import-export-driver.jar [-a] [--acls] [-b] [--bag-algorithms
        <algorithms>] -d <dir> [-f <path>] [-g <profile>] [-G <path>] [-h] [-i]
        [-L] [-l <rdfLang>] -m <mode> [-M <map>] [--membership] [-p <predicates>]
-       [-r <resource>] [-R <uri>] [-s <format>] [-t] [-T <num>] [-u <user>] [-V]
-       [-w <writeConfig>] [-x]
+       [-r <resource>] [-R <uri>] [-s <format>] [--skip-tombstones] [-t] [-T
+       <num>] [-u <user>] [-V] [-w <writeConfig>] [-x]
     -a,--auditLog                       Enable audit log creation, disabled by
                                         default
        --acls                           When present this flag indicates that
@@ -83,6 +83,8 @@ usage: java -jar import-export-driver.jar [-a] [--acls] [-b] [--bag-algorithms
                                         fedora-import-export: [tar]
                                         metaarchive: [tar]
                                         perseids: [zip, tar]
+       --skip-tombstones                Skip tombstones errors during export,
+                                        disabled by default
     -t,--overwriteTombstones            When importing, overwrite "tombstones"
                                         left behind after resources were
                                         deleted.

--- a/src/main/java/org/fcrepo/importexport/ArgParser.java
+++ b/src/main/java/org/fcrepo/importexport/ArgParser.java
@@ -293,6 +293,12 @@ public class ArgParser {
                 .desc("Enable audit log creation, disabled by default")
                 .required(false).build());
 
+        configOptions.addOption(Option.builder()
+                .longOpt("skip-tombstones")
+                .required(false)
+                .desc("Skip tombstones errors during export, disabled by default")
+                .build());
+
     }
 
     /**
@@ -486,6 +492,8 @@ public class ArgParser {
             config.setResourceFile(Paths.get(cmd.getOptionValue('f')));
         }
 
+        config.setSkipTombstoneErrors(cmd.hasOption("skip-tombstones"));
+
         return config;
     }
 
@@ -551,7 +559,7 @@ public class ArgParser {
     /**
      * Get a new client
      *
-     * @return
+     * @return the FcrepoClientBuilder
      */
     private FcrepoClient.FcrepoClientBuilder clientBuilder() {
         return FcrepoClient.client();
@@ -651,6 +659,8 @@ public class ArgParser {
                 c.setThreadCount(Integer.parseInt(entry.getValue()));
             } else if (entry.getKey().equalsIgnoreCase("resourceFile")) {
                 c.setResourceFile(Paths.get(entry.getValue()));
+            } else if (entry.getKey().equalsIgnoreCase("membership")) {
+                c.setIncludeMembership(parseBoolean("membership", entry.getValue(), lineNumber));
             } else {
                 throw new java.text.ParseException(String.format("Unknown configuration key: %1$s", entry.getKey()),
                     lineNumber);

--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -83,6 +83,8 @@ public class Config {
 
     private boolean auditLog = false;
 
+    private boolean skipTombstoneErrors = false;
+
     /**
      * This method returns true if the configuration is set for 'import'
      *
@@ -701,5 +703,19 @@ public class Config {
      */
     public void setResourceFile(final Path resourceFile) {
         this.resourceFile = resourceFile;
+    }
+
+    /**
+     * @return true if tombstone errors should be skipped
+     */
+    public boolean isSkipTombstoneErrors() {
+        return skipTombstoneErrors;
+    }
+
+    /**
+     * @param skipTombstoneErrors true if tombstone errors should be skipped
+     */
+    public void setSkipTombstoneErrors(final boolean skipTombstoneErrors) {
+        this.skipTombstoneErrors = skipTombstoneErrors;
     }
 }

--- a/src/main/java/org/fcrepo/importexport/common/TombstoneFoundException.java
+++ b/src/main/java/org/fcrepo/importexport/common/TombstoneFoundException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.importexport.common;
+
+import java.net.URI;
+
+/**
+ * Exception thrown when a tombstone is found during export.
+ * @author whikloj
+ */
+public class TombstoneFoundException extends RuntimeException {
+  /**
+   * Default constructor: provides a default message.
+   * @param uri the URI of the requested resource
+   */
+  public TombstoneFoundException(final URI uri) {
+    super("Tombstone found at " + uri);
+  }
+}

--- a/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
+++ b/src/main/java/org/fcrepo/importexport/common/TransferProcess.java
@@ -170,6 +170,8 @@ public interface TransferProcess {
             throw new AuthorizationDeniedRuntimeException(user, uri);
         case 404:
             throw new ResourceNotFoundRuntimeException(uri);
+        case 410:
+            throw new TombstoneFoundException(uri);
         default:
             if (response.getStatusCode() < 200 || response.getStatusCode() > 307) {
                 throw new RuntimeException("Export operation failed: unexpected status "


### PR DESCRIPTION
JIRA Ticket:  https://fedora-repository.atlassian.net/browse/FCREPO-3969
Resolves: #172 

While tombstones should not appear as ldp:contains triples in Fedora, if they do they would cause failures in an export. This new `--skip-tombstones` flag would allow the export to continue.

As this behaviour is not normal for Fedora, it is hard to test outside of unit tests 🤷 