### PR TITLE
Add option to parse RDF resource as a stream

### DIFF
--- a/src/main/java/org/fcrepo/importexport/common/Config.java
+++ b/src/main/java/org/fcrepo/importexport/common/Config.java
@@ -48,6 +48,7 @@ public class Config {
 
     public static final String DEFAULT_RDF_LANG = "text/turtle";
     public static final String DEFAULT_RDF_EXT = getRDFExtension(DEFAULT_RDF_LANG);
+    public static final String DEFAULT_STREAMING_RDF_LANG = "application/n-triples";
     public static final String[] DEFAULT_PREDICATES = new String[] { CONTAINS.toString() };
 
     private String mode;
@@ -82,6 +83,12 @@ public class Config {
     private Path resourceFile;
 
     private boolean auditLog = false;
+
+    private boolean streaming = false;
+    /**
+     * Flag indicating whether the RDF language has been set by the user.
+     */
+    private boolean rdf_set = false;
 
     private boolean skipTombstoneErrors = false;
 
@@ -474,6 +481,7 @@ public class Config {
      * @param language of the exported RDF
      */
     public void setRdfLanguage(final String language) {
+        this.rdf_set = true;
         this.rdfLanguage = language;
         this.rdfExtension = getRDFExtension(language);
     }
@@ -481,10 +489,17 @@ public class Config {
     /**
      * Gets the RDF language
      *
-     * @return rdfLanguage
+     * @return rdfLanguage if set or default RDF language depending on streaming
      */
     public String getRdfLanguage() {
-        return rdfLanguage;
+        return (this.rdf_set ? rdfLanguage : (this.isStreaming() ? DEFAULT_STREAMING_RDF_LANG : DEFAULT_RDF_LANG));
+    }
+
+    /**
+     * @return boolean Whether the RDF language has been set by the user.
+     */
+    public boolean isRdfSet() {
+        return rdf_set;
     }
 
     /**
@@ -608,6 +623,8 @@ public class Config {
         if (resourceFile != null) {
             map.put("resourceFile", resourceFile.toAbsolutePath().toString());
         }
+        map.put("streaming", Boolean.toString(this.streaming));
+        map.put("isRdfSet", Boolean.toString(this.isRdfSet()));
         return map;
     }
 
@@ -703,6 +720,20 @@ public class Config {
      */
     public void setResourceFile(final Path resourceFile) {
         this.resourceFile = resourceFile;
+    }
+
+    /**
+     * @return true if mode is export and streaming is enabled
+     */
+    public boolean isStreaming() {
+        return this.streaming;
+    }
+
+    /**
+     * @param streaming true if streaming is enabled for export
+     */
+    public void setStreaming(final boolean streaming) {
+        this.streaming = streaming;
     }
 
     /**

--- a/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
+++ b/src/main/java/org/fcrepo/importexport/common/FcrepoConstants.java
@@ -69,6 +69,7 @@ public abstract class FcrepoConstants {
             createResource("http://fedora.info/definitions/fcrepo#PreferInboundReferences");
     public static final Resource PAIRTREE = createResource(REPOSITORY_NAMESPACE + "Pairtree");
     public static final Resource REPOSITORY_ROOT = createResource(REPOSITORY_NAMESPACE + "RepositoryRoot");
+    public static final Resource NON_RDF_DESCRIPTION = createResource(REPOSITORY_NAMESPACE + "NonRdfSourceDescription");
 
     public static final String BAG_INFO_FIELDNAME = "Bag-Info";
 

--- a/src/main/java/org/fcrepo/importexport/exporter/StreamTripleHandler.java
+++ b/src/main/java/org/fcrepo/importexport/exporter/StreamTripleHandler.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.importexport.exporter;
+
+import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.sparql.core.Quad;
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.client.FcrepoResponse;
+import org.fcrepo.importexport.common.Config;
+import org.slf4j.Logger;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
+import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
+import static org.fcrepo.importexport.common.TransferProcess.checkValidResponse;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * A class to handle triples from a RDFstream
+ * @author whikloj
+ */
+public class StreamTripleHandler implements StreamRDF {
+
+    // The configuration
+    private final Config config;
+
+    // The exporter to use
+    private final Exporter exporter;
+
+    // The URI of the current resource
+    private Node uri;
+
+    // The output stream to write to
+    private OutputStream outputStream = null;
+
+    // The output file to write to
+    protected File file;
+
+    // The other resources to export found in the triples
+    private List<Node> exports = new ArrayList<>();
+
+    // The predicates to include in the export as a list of nodes
+    private final List<Node> predicates = new ArrayList<>();
+
+    // The RDF language to write in (currently only NTRIPLES)
+    private final Lang rdfLanguage;
+
+    // The FcrepoClient to perform head requests to exclude binaries if necessary.
+    private final FcrepoClient client;
+
+    private static final Logger LOGGER = getLogger(StreamTripleHandler.class);
+
+    // The URI for a binary resource rdf:type
+    private static final URI binaryURI = URI.create(NON_RDF_SOURCE.getURI());
+
+    /**
+     * Constructor
+     * @param config the configuration
+     * @param transferProcess the exporter
+     * @param client the FcrepoClient
+     */
+    public StreamTripleHandler (
+            final Config config,
+            final Exporter transferProcess,
+            final FcrepoClient client
+    ) {
+        this.config = config;
+        this.rdfLanguage = contentTypeToLang(config.getRdfLanguage());
+        this.exporter = transferProcess;
+        this.client = client;
+        this.predicates.addAll(Arrays.stream(config.getPredicates()).map(ResourceFactory::createProperty)
+                .map(Property::asNode).collect(Collectors.toList()));
+    }
+
+    /**
+     * Set the resource URI.
+     * @param resource the resource URI
+     * @return this
+     */
+    public StreamTripleHandler setResource(final URI resource) {
+        this.uri = ResourceFactory.createResource(resource.toString()).asNode();
+        return this;
+    }
+
+    /**
+     * Set the file to write to.
+     * @param file the file to write to
+     * @return this
+     */
+    public StreamTripleHandler setFile(final File file) {
+        this.file = file;
+        return this;
+    }
+
+    @Override
+    public void start() {
+        LOGGER.trace("Starting stream triple handler");
+        exports = new ArrayList<>();
+        if (file == null) {
+            LOGGER.error("No file set for output stream");
+            return;
+        }
+        if (uri == null) {
+            LOGGER.error("No resource URI set");
+            return;
+        }
+        if (!file.getParentFile().exists()) {
+            file.getParentFile().mkdirs();
+        }
+        try {
+            outputStream = new BufferedOutputStream(new FileOutputStream(file));
+        } catch (FileNotFoundException e) {
+            LOGGER.error("Error creating output stream: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void triple(final Triple triple) {
+        LOGGER.trace("Triple: {}", triple);
+        if (triple.subjectMatches(uri)) {
+            LOGGER.debug("Found triple with subject: {}", uri);
+            if (predicates.stream().anyMatch(triple::predicateMatches)) {
+                LOGGER.trace("Capturing object resource {} with predicate {}", uri, triple.getPredicate());
+                if (!config.isIncludeBinaries()) {
+                    try {
+                        if (isBinary(URI.create(triple.getObject().getURI()))) {
+                            LOGGER.debug("Skipping binary resource: {}", triple.getObject());
+                            return;
+                        }
+                    } catch (IOException | FcrepoOperationFailedException e) {
+                        LOGGER.error("Error checking if resource is binary: {}", e.getMessage());
+                    }
+                }
+                exports.add(triple.getObject());
+            }
+        } else if (triple.objectMatches(uri)) {
+            LOGGER.debug("Found triple with object: {}", uri);
+            if (config.retrieveInbound()) {
+                LOGGER.trace("Capturing inbound reference: {}", uri);
+                exports.add(triple.getSubject());
+            } else {
+                LOGGER.debug("Skipping inbound reference: {}", uri);
+                return;
+            }
+        }
+        final Graph graph = Factory.createDefaultGraph();
+        graph.add(triple);
+        RDFDataMgr.write(outputStream, graph, rdfLanguage);
+    }
+
+    @Override
+    public void quad(final Quad quad) {
+        LOGGER.trace("Quad: {}", quad);
+        this.triple(quad.asTriple());
+    }
+
+    @Override
+    public void base(final String s) {
+        LOGGER.trace("Base: {}", s);
+        // no-op
+    }
+
+    @Override
+    public void prefix(final String s, final String s1) {
+        LOGGER.trace("Prefix: {} {}", s, s1);
+        // no-op
+    }
+
+    @Override
+    public void finish() {
+        LOGGER.debug("Finishing stream triple handler");
+        try {
+            if (outputStream != null) {
+                outputStream.close();
+                if (this.file != null && this.file.exists()) {
+                    exporter.generateChecksums(this.file);
+                }
+            }
+            if (!exports.isEmpty()) {
+                LOGGER.info("Exporting {} resources linked to {}", exports.size(), uri);
+                for (Node export : exports) {
+                    exporter.export(URI.create(export.getURI()));
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.error("Error closing output stream: {}", e.getMessage());
+        } finally {
+            // Reset the output stream and file
+            this.outputStream = null;
+            this.file = null;
+            this.uri = null;
+        }
+    }
+
+    /**
+     * Check if the resource at obj is a binary.
+     * @param obj the URI of the resource
+     * @return true if the resource is a binary
+     * @throws IOException if there is an error performing the HEAD request
+     * @throws FcrepoOperationFailedException if there is an error performing the HEAD request
+     */
+    private boolean isBinary(final URI obj) throws IOException, FcrepoOperationFailedException {
+        try (final FcrepoResponse resp = client.head(URI.create(obj.toString())).disableRedirects().perform()) {
+            checkValidResponse(resp, URI.create(obj.toString()), config.getUsername());
+            final List<URI> linkHeaders = resp.getLinkHeaders("type");
+            return linkHeaders.contains(binaryURI);
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/importexport/ArgParserTest.java
+++ b/src/test/java/org/fcrepo/importexport/ArgParserTest.java
@@ -19,6 +19,7 @@ package org.fcrepo.importexport;
 
 import static org.duraspace.bagit.profile.BagProfile.BuiltIn.FEDORA_IMPORT_EXPORT;
 import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -395,5 +396,70 @@ public class ArgParserTest {
         Assert.assertEquals("false", config.get("auditLog"));
         Assert.assertEquals("false", config.get("versions"));
         Assert.assertNull(config.get("writeConfig"));
+    }
+
+    @Test
+    public void testStreamingImport() {
+        assertThrows(RuntimeException.class, () -> parser.parseConfiguration(ArrayUtils.addAll(MINIMAL_VALID_IMPORT_ARGS, "--streaming")));
+    }
+
+    @Test
+    public void testStreamingExportRdfLang() {
+        assertThrows(RuntimeException.class, () -> parser.parseConfiguration(ArrayUtils.addAll(MINIMAL_VALID_EXPORT_ARGS, "--streaming", "-l", "application/ld+json")));
+    }
+
+    /**
+     * Test that default RDF language is set to application/n-triples when streaming is enabled and isRdfSet is false
+     */
+    @Test
+    public void testStreamingExport() {
+        final Map<String, String> config = parser.parseConfiguration(ArrayUtils.addAll(MINIMAL_VALID_EXPORT_ARGS, "--streaming")).getMap();
+        Assert.assertEquals("export", config.get("mode"));
+        Assert.assertEquals("http://localhost:8080/rest/1", config.get("resource"));
+        Assert.assertEquals("/tmp/rdf", config.get("dir"));
+        Assert.assertEquals("application/n-triples", config.get("rdfLang"));
+        Assert.assertEquals("false", config.get("isRdfSet"));
+    }
+
+    /**
+     * Test that default RDF language is set to application/n-triples when streaming is enabled and isRdfSet is true
+     */
+    @Test
+    public void testStreamingExportSetRdfLang() {
+        final Map<String, String> config = parser.parseConfiguration(ArrayUtils.addAll(MINIMAL_VALID_EXPORT_ARGS, "--streaming", "-l", "application/n-triples")).getMap();
+        Assert.assertEquals("export", config.get("mode"));
+        Assert.assertEquals("http://localhost:8080/rest/1", config.get("resource"));
+        Assert.assertEquals("/tmp/rdf", config.get("dir"));
+        Assert.assertEquals("application/n-triples", config.get("rdfLang"));
+        Assert.assertEquals("true", config.get("streaming"));
+        Assert.assertEquals("true", config.get("isRdfSet"));
+    }
+
+    /**
+     * Test that default RDF language is set to application/n-triples when streaming is not enabled and isRdfSet is true
+     */
+    @Test
+    public void testNonStreamingExportRdfSet() {
+        final Map<String, String> config = parser.parseConfiguration(ArrayUtils.addAll(MINIMAL_VALID_EXPORT_ARGS, "-l", "application/n-triples")).getMap();
+        Assert.assertEquals("export", config.get("mode"));
+        Assert.assertEquals("http://localhost:8080/rest/1", config.get("resource"));
+        Assert.assertEquals("/tmp/rdf", config.get("dir"));
+        Assert.assertEquals("application/n-triples", config.get("rdfLang"));
+        Assert.assertEquals("false", config.get("streaming"));
+        Assert.assertEquals("true", config.get("isRdfSet"));
+    }
+
+    /**
+     * Test that default RDF language is set to text/turtle when streaming is not enabled and isRdfSet is false
+     */
+    @Test
+    public void testNonStreamingExportRdf() {
+        final Map<String, String> config = parser.parseConfiguration(ArrayUtils.addAll(MINIMAL_VALID_EXPORT_ARGS)).getMap();
+        Assert.assertEquals("export", config.get("mode"));
+        Assert.assertEquals("http://localhost:8080/rest/1", config.get("resource"));
+        Assert.assertEquals("/tmp/rdf", config.get("dir"));
+        Assert.assertEquals("text/turtle", config.get("rdfLang"));
+        Assert.assertEquals("false", config.get("streaming"));
+        Assert.assertEquals("false", config.get("isRdfSet"));
     }
 }

--- a/src/test/java/org/fcrepo/importexport/exporter/ExportStreamTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExportStreamTest.java
@@ -1,0 +1,555 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.importexport.exporter;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.vocabulary.DC;
+import org.duraspace.bagit.BagItDigest;
+import org.duraspace.bagit.profile.BagProfile;
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.client.FcrepoResponse;
+import org.fcrepo.client.HeadBuilder;
+import org.fcrepo.importexport.common.AuthenticationRequiredRuntimeException;
+import org.fcrepo.importexport.common.Config;
+import org.fcrepo.importexport.test.util.ResponseMocker;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.apache.commons.io.FileUtils.readLines;
+import static org.duraspace.bagit.profile.BagProfileConstants.BAGIT_PROFILE_IDENTIFIER;
+import static org.fcrepo.importexport.common.FcrepoConstants.BINARY_EXTENSION;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
+import static org.fcrepo.importexport.common.FcrepoConstants.DESCRIBEDBY;
+import static org.fcrepo.importexport.common.FcrepoConstants.EXTERNAL_RESOURCE_EXTENSION;
+import static org.fcrepo.importexport.common.FcrepoConstants.HEADERS_EXTENSION;
+import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_DESCRIPTION;
+import static org.fcrepo.importexport.common.FcrepoConstants.RDF_SOURCE;
+import static org.fcrepo.importexport.common.FcrepoConstants.RDF_TYPE;
+import static org.fcrepo.importexport.common.FcrepoConstants.REPOSITORY_NAMESPACE;
+import static org.fcrepo.importexport.common.FcrepoConstants.REPOSITORY_ROOT;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the StreamExporter class.
+ */
+public class ExportStreamTest extends ExportTestBase {
+
+    private Config config;
+
+    private String id;
+
+    /**
+     * The resources to be exported.
+     * rootResource (in ExportTestBase) is the repository root.
+     * resource (in ExportTestBase) is a container.
+     * resource2 is a binary.
+     * resource3 is a description of resource2.
+     * resource4 is a container, often used as an alternate description of resource2.
+     */
+    private URI resource2;
+    private URI resource3;
+    private URI resource4;
+
+    private StreamExporterWrapper exporter;
+    private StreamTripleHandlerWrapper handler;
+
+    public ExportStreamTest() throws URISyntaxException {
+        super();
+        exportDirectory = new File("target/stream-export").getAbsolutePath();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        id = UUID.randomUUID().toString();
+        resource = URI.create("http://localhost:8080/rest/" + id);
+
+        config = new Config();
+        config.setStreaming(true);
+        config.setRdfLanguage("application/n-triples");
+        config.setBaseDirectory(exportDirectory);
+        config.setResource(resource);
+        final String rootBody = "<" + rootResource + "> <" + CONTAINS + "> <" + resource + "> ." +
+                "<" + rootResource + "> <" + RDF_TYPE + "> <" + REPOSITORY_ROOT + "> .";
+        mockResponse(rootResource, containerLinks, new ArrayList<>(), rootBody);
+
+        resource2 = URI.create("http://localhost:8080/rest/file1");
+        resource3 = URI.create("http://localhost:8080/rest/file1/fcr:metadata");
+        resource4 = URI.create("http://localhost:8080/rest/alt_description");
+
+        describedbyLinks.add(resource3);
+        describedbyLinks.add(resource4);
+
+        mockResponse(resource, containerLinks, emptyList(), "<" + resource + "> <" + RDF_TYPE +
+                "> <" + RDF_SOURCE + "> .\n <" + resource + "> <" + CONTAINS + "> <" + resource2 + "> .");
+        mockResponse(resource2, binaryLinks, describedbyLinks,null,  "binary", "image/tiff");
+        mockResponse(resource3, descriptionLinks, new ArrayList<>(), "<" + resource3 + "> <" + RDF_TYPE +
+                "> <" + NON_RDF_DESCRIPTION + "> .");
+        mockResponse(resource4, containerLinks, new ArrayList<>(), "<" + resource4 + "> <" + RDF_TYPE +
+                "> <" + RDF_SOURCE + "> .");
+
+        reconfigureExporter();
+    }
+
+    /**
+     * Reconfigure the exporter and handler to use the current configuration.
+     */
+    private void reconfigureExporter() {
+        exporter = new StreamExporterWrapper(config, clientBuilder);
+        handler = new StreamTripleHandlerWrapper(config, exporter, client);
+        exporter.setHandler(handler);
+    }
+
+    @Test
+    public void testContent() throws Exception {
+        final StreamTripleHandlerWrapper handler = new StreamTripleHandlerWrapper(config, exporter, client);
+        exporter.setHandler(handler);
+        final String content = "<" + resource + "> <" + DC.title + "> \"Title\" .\n" +
+                "<" + resource + "> <" + DC.creator + "> \"Creator\" .\n";
+        mockResponse(resource, descriptionLinks, describedbyLinks, content);
+        exporter.run();
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
+    }
+
+    @Test
+    public void testBinaryExport() throws Exception {
+        config.setIncludeBinaries(true);
+        resource2 = URI.create("http://localhost:8080/rest/" + id + "/fcr:metadata");
+        final String alternateID = UUID.randomUUID().toString();
+        resource3 = URI.create("http://localhost:8080/rest/" + alternateID);
+
+        final String content = "<" + resource  + "> <" + DC.title + "> \"Title\" .\n" +
+                "<" + resource + "> <" + DC.creator + "> \"Creator\" .\n" +
+                "<" + resource + "> <" + DESCRIBEDBY.getURI() + "> <" + resource2 + "> .\n";
+        describedbyLinks.add(resource2);
+        describedbyLinks.add(resource3);
+        mockResponse(resource, binaryLinks, describedbyLinks, "Some binary content");
+        mockResponse(resource2, containerLinks, emptyList(), content);
+        final String alternate = "<" + resource + "> <" + DC.title + "> \"Alternate Title\" .\n" +
+                "<" + resource + "> <" + DC.creator + "> \"Alternate Creator\" .\n";
+        mockResponse(resource3, containerLinks, emptyList(), alternate);
+        exporter.run();
+        assertTrue(exporter.wroteFile(exportDirectory + "/rest/" + id + BINARY_EXTENSION));
+        assertTrue(exporter.wroteFile(exportDirectory + "/rest/" + id + BINARY_EXTENSION + ".headers"));
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + "/fcr%3Ametadata.nt"));
+        assertTrue(exporter.wroteFile(exportDirectory + "/rest/" + id + "/fcr%3Ametadata.nt.headers"));
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + alternateID + ".nt"));
+        assertTrue(exporter.wroteFile(exportDirectory + "/rest/" + alternateID + ".nt.headers"));
+    }
+
+    @Test
+    public void testExportBinaryAndDescription() throws Exception, FcrepoOperationFailedException {
+        config.setIncludeBinaries(true);
+        config.setResource(resource2);
+
+        reconfigureExporter();
+
+        exporter.run();
+        assertTrue(exporter.wroteFile(exportDirectory + "/rest/file1" + BINARY_EXTENSION));
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/file1/fcr%3Ametadata.nt"));
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/alt_description.nt"));
+        assertTrue(exporter.wroteFile(exportDirectory + "/rest/file1" + BINARY_EXTENSION + HEADERS_EXTENSION));
+        assertTrue(exporter.wroteFile(exportDirectory + "/rest/file1/fcr%3Ametadata.nt" + HEADERS_EXTENSION));
+        assertTrue(exporter.wroteFile(exportDirectory + "/rest/alt_description.nt" + HEADERS_EXTENSION));
+    }
+
+    @Test
+    public void testExportBag() throws Exception {
+        config.setIncludeBinaries(true);
+        config.setRetrieveExternal(true);
+        config.setResource(resource2);
+        config.setBagProfile("default");
+        config.setBagConfigPath("src/test/resources/configs/bagit-config.yml");
+
+        reconfigureExporter();
+
+        exporter.run();
+        assertTrue(exporter.wroteFile(exportDirectory + "/data/rest/file1" + BINARY_EXTENSION));
+        assertTrue(handler.wroteFile(exportDirectory + "/data/rest/file1/fcr%3Ametadata.nt"));
+        assertTrue(handler.wroteFile(exportDirectory + "/data/rest/alt_description.nt"));
+
+        final File baginfo = new File(exportDirectory + "/bag-info.txt");
+        assertTrue(baginfo.exists());
+        final List<String> baginfoLines = readLines(baginfo, UTF_8);
+        assertTrue(baginfoLines.contains("Bag-Size: 311 bytes"));
+        assertTrue(baginfoLines.contains("Payload-Oxum: 311.3"));
+        assertTrue(baginfoLines.contains("Source-Organization: My University"));
+
+        // verify all manifests are written and contain entries for the exported files
+        final String manifestFiles = ".*alt_description\\.nt|.*file1\\.binary|.*fcr%3Ametadata\\.nt";
+        final File sha1Manifest = new File(exportDirectory + "/manifest-sha1.txt");
+        assertTrue(sha1Manifest.exists());
+        assertTrue(Files.lines(sha1Manifest.toPath()).allMatch(string -> string.matches(manifestFiles)));
+
+        // verify all tag files are written to the tag manifest (checksum + expected name)
+        final String tagFiles = ".*bagit\\.txt|.*bag-info\\.txt|.*aptrust-info\\.txt|.*manifest-sha1\\.txt";
+        final File sha1TagManifest = new File(exportDirectory + "/tagmanifest-sha1.txt");
+        assertTrue(sha1TagManifest.exists());
+        assertTrue(Files.lines(sha1TagManifest.toPath()).allMatch(string -> string.matches(tagFiles)));
+    }
+
+    @Test
+    public void testExportApTrustBag() throws Exception {
+        createAptrustBagConfig();
+        config.setBagAlgorithms(new String[]{BagItDigest.SHA256.bagitName()});
+        config.setBagSerialization("tar");
+        config.setBagConfigPath("src/test/resources/configs/bagit-config.yml");
+
+        reconfigureExporter();
+
+        exporter.run();
+
+        assertTrue(Files.exists(Paths.get(exportDirectory, "manifest-md5.txt")));
+        assertTrue(Files.exists(Paths.get(exportDirectory, "manifest-sha256.txt")));
+        assertTrue(exporter.wroteFile(exportDirectory + "/data/rest/file1" + BINARY_EXTENSION));
+        assertTrue(handler.wroteFile(exportDirectory + "/data/rest/file1/fcr%3Ametadata.nt"));
+        assertTrue(handler.wroteFile(exportDirectory + "/data/rest/alt_description.nt"));
+
+        assertTrue(Files.exists(Paths.get(exportDirectory + ".tar")));
+        tearDownFiles.add(new File(exportDirectory + ".tar"));
+
+        // instead of extracting the tarball, search for the aptrust-info.txt and load it if found
+        List<String> aptrustInfoLines = emptyList();
+        try (InputStream is = Files.newInputStream(Paths.get(exportDirectory + ".tar"));
+             TarArchiveInputStream tais = new TarArchiveInputStream(is)) {
+            TarArchiveEntry entry;
+            while ((entry = tais.getNextTarEntry()) != null) {
+                if (entry.getName().equalsIgnoreCase("stream-export/aptrust-info.txt")) {
+                    aptrustInfoLines = IOUtils.readLines(tais, Charset.defaultCharset());
+                    break;
+                }
+            }
+        }
+
+        // And check the aptrust-info.txt was found (isNotEmpty) and expected entries exist
+        assertFalse(aptrustInfoLines.isEmpty());
+        assertTrue(aptrustInfoLines.contains("Access: Restricted"));
+        assertTrue(aptrustInfoLines.contains("Title: My Title"));
+        assertTrue(aptrustInfoLines.contains("Storage-Option: Standard"));
+
+    }
+
+    @Test
+    public void testExportApTrustBagValidationError() {
+        createAptrustBagConfig();
+        config.setBagConfigPath("src/test/resources/configs/bagit-config-missing-access.yml");
+
+        assertThrows(RuntimeException.class, () -> new StreamExporterWrapper(config, clientBuilder));
+    }
+
+    @Test
+    public void testExportApTrustBagInvalidUserAlgorithm() {
+        createAptrustBagConfig();
+        config.setBagAlgorithms(new String[]{BagItDigest.SHA1.bagitName()});
+        config.setBagSerialization("tar");
+        config.setBagConfigPath("src/test/resources/configs/bagit-config.yml");
+
+        assertThrows(RuntimeException.class, () -> new StreamExporterWrapper(config, clientBuilder));
+    }
+
+    @Test
+    public void testExportBeyondTheRepositoryBag() throws IOException {
+        final BagProfile profile = new BagProfile(BagProfile.BuiltIn.BEYOND_THE_REPOSITORY);
+        final String bagConfigPath = "src/test/resources/configs/bagit-config-no-aptrust.yml";
+        final String bagProfileId = BAGIT_PROFILE_IDENTIFIER + ": " + profile.getIdentifier();
+
+        config.setResource(resource2);
+        config.setIncludeBinaries(true);
+        config.setRetrieveExternal(true);
+        config.setBagProfile("beyondtherepository");
+        config.setBagConfigPath(bagConfigPath);
+
+        reconfigureExporter();
+
+        exporter.run();
+        assertTrue(exporter.wroteFile(exportDirectory + "/data/rest/file1" + BINARY_EXTENSION));
+        assertTrue(handler.wroteFile(exportDirectory + "/data/rest/file1/fcr%3Ametadata.nt"));
+        assertTrue(handler.wroteFile(exportDirectory + "/data/rest/alt_description.nt"));
+
+        final File bagInfo = new File(exportDirectory + "/bag-info.txt");
+        assertTrue(bagInfo.exists());
+        final List<String> bagInfoLines = readLines(bagInfo, UTF_8);
+        assertTrue(bagInfoLines.contains("Bag-Size: 311 bytes"));
+        assertTrue(bagInfoLines.contains("Payload-Oxum: 311.3"));
+        assertTrue(bagInfoLines.contains("Source-Organization: My University"));
+        assertTrue(bagInfoLines.contains(bagProfileId));
+    }
+
+    @Test
+    public void testExportBeyondTheRepositoryBagValidationError() {
+        config.setIncludeBinaries(true);
+        config.setResource(resource2);
+        config.setBagProfile("beyondtherepository");
+        config.setBagConfigPath("src/test/resources/configs/bagit-config-missing-source-org.yml");
+
+        assertThrows(RuntimeException.class, () -> new StreamExporterWrapper(config, clientBuilder));
+    }
+
+    @Test
+    public void testExportNoBinaryAndDescription() throws Exception, FcrepoOperationFailedException {
+        config.setIncludeBinaries(false);
+        config.setResource(resource2);
+
+        reconfigureExporter();
+
+        exporter.run();
+        assertFalse(exporter.wroteFile(exportDirectory + "/rest/file1" + BINARY_EXTENSION));
+        assertFalse(handler.wroteFile(exportDirectory + "/rest/file1/fcr%3Ametadata.nt"));
+        assertFalse(handler.wroteFile(exportDirectory + "/rest/alt_description.nt"));
+    }
+
+    @Test
+    public void testExternalContent() throws Exception {
+        config.setIncludeBinaries(true);
+        config.setResource(resource2);
+
+        reconfigureExporter();
+
+        final HeadBuilder headBuilder = mock(HeadBuilder.class);
+        final FcrepoResponse headResponse = mock(FcrepoResponse.class);
+        when(client.head(eq(resource2))).thenReturn(headBuilder);
+        when(headBuilder.disableRedirects()).thenReturn(headBuilder);
+        when(headBuilder.perform()).thenReturn(headResponse);
+        when(headResponse.getUrl()).thenReturn(resource3);
+        when(headResponse.getLinkHeaders(eq("describedby"))).thenReturn(describedbyLinks);
+        when(headResponse.getStatusCode()).thenReturn(307);
+        when(headResponse.getLinkHeaders(eq("type"))).thenReturn(binaryLinks);
+        when(headResponse.getHeaderValue("Content-Location")).thenReturn("http://www.example.com/file");
+
+        exporter.run();
+
+        final String externalResourceFile = exportDirectory + "/rest/file1" + EXTERNAL_RESOURCE_EXTENSION;
+        assertTrue(exporter.wroteFile(externalResourceFile));
+        assertTrue(new File(externalResourceFile).exists());
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/file1/fcr%3Ametadata.nt"));
+    }
+
+    @Test
+    public void testExportContainer() throws Exception {
+        config.setIncludeBinaries(true);
+        config.setResource(resource);
+
+        reconfigureExporter();
+
+        exporter.run();
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
+    }
+
+    @Test
+    public void testExportAcl() throws Exception {
+        config.setIncludeAcls(true);
+        config.setIncludeBinaries(true);
+        config.setResource(resource);
+
+        final URI resourceAcl = URI.create(resource.toString() + "/fcr:acl");
+
+        mockResponse(resource, containerLinks, new ArrayList<>(), resourceAcl,"<" + resource
+                + "> <" + RDF_TYPE + "> <" + REPOSITORY_NAMESPACE + "RepositoryRoot> ."
+                , null);
+        mockResponse(resourceAcl, containerLinks, emptyList(), "<" + resourceAcl + "> <" + RDF_TYPE + "> <" +
+                RDF_SOURCE + "> .");
+
+        reconfigureExporter();
+
+        exporter.run();
+
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + "/fcr%3Aacl.nt"));
+    }
+
+    @Test
+    public void testExportAclRecursive() throws Exception {
+        config.setIncludeAcls(true);
+        config.setIncludeBinaries(true);
+        config.setResource(resource);
+
+        final URI resourceAcl = URI.create(resource.toString() + "/fcr:acl");
+        final URI resource2 = URI.create(resource.toString() + "/2");
+        final URI resource3 = URI.create(resource2.toString() + "/fcr%3Ametadata");
+
+        mockResponse(resource, containerLinks, new ArrayList<>(), resourceAcl,"<" + resource
+                        + "> <" + RDF_TYPE + "> <" + REPOSITORY_NAMESPACE + "RepositoryRoot> .\n"
+                        + "<" + resource + "> <" + CONTAINS + "> <" + resource2 + "> ."
+                , null);
+        mockResponse(resourceAcl, containerLinks, emptyList(), "<" + resourceAcl + "> <" + RDF_TYPE + "> <" +
+                RDF_SOURCE + "> .");
+        mockResponse(resource2, binaryLinks, singletonList(resource3), "binary");
+        mockResponse(resource3, containerLinks, emptyList(), "<" + resource3 + "> <" + RDF_TYPE + "> <" +
+                RDF_SOURCE + "> .");
+
+        reconfigureExporter();
+
+        exporter.run();
+
+        final String first_resource_path = exportDirectory + "/rest/" + id;
+        assertTrue(handler.wroteFile(first_resource_path + ".nt"));
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + "/fcr%3Aacl.nt"));
+        assertTrue(exporter.wroteFile(first_resource_path + "/2" + BINARY_EXTENSION));
+        assertTrue(exporter.wroteFile(first_resource_path + "/2" + BINARY_EXTENSION + ".headers"));
+        assertTrue(handler.wroteFile(first_resource_path + "/2/fcr%3Ametadata.nt"));
+    }
+
+    @Test
+    public void testUnauthenticatedExportWhenAuthorizationIsRequired() throws Exception {
+        config.setIncludeBinaries(true);
+        config.setResource(resource);
+
+        reconfigureExporter();
+
+        ResponseMocker.mockHeadResponseError(client, resource, 401);
+
+        assertThrows(AuthenticationRequiredRuntimeException.class, () -> exporter.run());
+    }
+
+    @Test
+    public void testMetadataOnlyDoesNotExportBinaries() throws Exception {
+        config.setResource(resource);
+
+        reconfigureExporter();
+
+        exporter.run();
+
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
+        assertFalse(exporter.wroteFile(exportDirectory + "/rest/file1" + BINARY_EXTENSION));
+    }
+
+    @Test
+    public void testMetadataOnlyExportsContainers() throws Exception {
+        config.setResource(resource);
+
+        reconfigureExporter();
+
+        exporter.run();
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
+    }
+
+    @Test
+    public void testRecursive() throws Exception {
+        final URI resource6 = URI.create("http://localhost:8080/rest/" + id + "/2");
+        mockResponse(resource, containerLinks, emptyList(), "<" + resource + "> <" + RDF_TYPE + "> <" + RDF_SOURCE + "> .\n" +
+                "<" + resource + "> <" + CONTAINS + "> <" + resource6 + "> .");
+        mockResponse(resource6, containerLinks, emptyList(), "<" + resource6 + "> <" + RDF_TYPE + "> <" + RDF_SOURCE + "> .");
+        config.setResource(resource);
+
+        reconfigureExporter();
+        exporter.run();
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
+        assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + "/2.nt"));
+    }
+
+    private void createAptrustBagConfig() {
+        config.setMode("export");
+        config.setBaseDirectory(exportDirectory);
+        config.setIncludeBinaries(true);
+        config.setPredicates(predicates);
+        config.setRdfLanguage("application/n-triples");
+        config.setResource(resource2);
+        config.setBagProfile("aptrust");
+    }
+}
+
+/**
+ * A wrapper around the Exporter class to allow for testing of the StreamTripleHandler.
+ */
+class StreamExporterWrapper extends Exporter {
+    private final List<String> writtenFiles = new ArrayList<>();
+
+    StreamExporterWrapper(
+            final Config config,
+            final FcrepoClient.FcrepoClientBuilder clientBuilder
+    ) {
+        super(config, clientBuilder);
+    }
+
+    @Override
+    void writeResponse(final URI uri, final InputStream in, final List<URI> describedby, final File file)
+            throws IOException, FcrepoOperationFailedException {
+        super.writeResponse(uri, in, describedby, file);
+        writtenFiles.add(file.getAbsolutePath());
+    }
+
+    @Override
+    void writeHeadersFile(final FcrepoResponse response, final File file) throws IOException {
+        super.writeHeadersFile(response, file);
+        writtenFiles.add(file.getAbsolutePath());
+
+    }
+
+    void setHandler(final StreamTripleHandler handler) {
+        this.streamTripleHandler = handler;
+    }
+
+    boolean wroteFile(final String file) {
+        return writtenFiles.contains(file);
+    }
+
+}
+
+/**
+ * A wrapper around the StreamTripleHandler class to allow for validating the files written.
+ */
+class StreamTripleHandlerWrapper extends StreamTripleHandler {
+
+    private final List<String> files = new ArrayList<>();
+
+    StreamTripleHandlerWrapper(
+            final Config config,
+            final Exporter transferProcess,
+            final FcrepoClient client
+    ) {
+        super(config, transferProcess, client);
+    }
+
+    @Override
+    public void finish() {
+        // Need to make a copy of the file before calling super.finish() because the file reference is set to null.
+        // The file is only written if the outputstream exists in finish().
+        final File file = this.file;
+        super.finish();
+        if (file.exists()) {
+            files.add(file.getAbsolutePath());
+        }
+    }
+
+    public boolean wroteFile(final String filename) {
+        return files.contains(filename);
+    }
+}

--- a/src/test/java/org/fcrepo/importexport/exporter/ExportStreamTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExportStreamTest.java
@@ -140,8 +140,6 @@ public class ExportStreamTest extends ExportTestBase {
 
     @Test
     public void testContent() throws Exception {
-        final StreamTripleHandlerWrapper handler = new StreamTripleHandlerWrapper(config, exporter, client);
-        exporter.setHandler(handler);
         final String content = "<" + resource + "> <" + DC.title + "> \"Title\" .\n" +
                 "<" + resource + "> <" + DC.creator + "> \"Creator\" .\n";
         mockResponse(resource, descriptionLinks, describedbyLinks, content);
@@ -179,8 +177,6 @@ public class ExportStreamTest extends ExportTestBase {
     public void testExportBinaryAndDescription() throws Exception, FcrepoOperationFailedException {
         config.setIncludeBinaries(true);
         config.setResource(resource2);
-
-        reconfigureExporter();
 
         exporter.run();
         assertTrue(exporter.wroteFile(exportDirectory + "/rest/file1" + BINARY_EXTENSION));
@@ -328,8 +324,6 @@ public class ExportStreamTest extends ExportTestBase {
         config.setIncludeBinaries(false);
         config.setResource(resource2);
 
-        reconfigureExporter();
-
         exporter.run();
         assertFalse(exporter.wroteFile(exportDirectory + "/rest/file1" + BINARY_EXTENSION));
         assertFalse(handler.wroteFile(exportDirectory + "/rest/file1/fcr%3Ametadata.nt"));
@@ -340,8 +334,6 @@ public class ExportStreamTest extends ExportTestBase {
     public void testExternalContent() throws Exception {
         config.setIncludeBinaries(true);
         config.setResource(resource2);
-
-        reconfigureExporter();
 
         final HeadBuilder headBuilder = mock(HeadBuilder.class);
         final FcrepoResponse headResponse = mock(FcrepoResponse.class);
@@ -367,8 +359,6 @@ public class ExportStreamTest extends ExportTestBase {
         config.setIncludeBinaries(true);
         config.setResource(resource);
 
-        reconfigureExporter();
-
         exporter.run();
         assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
     }
@@ -387,8 +377,6 @@ public class ExportStreamTest extends ExportTestBase {
         mockResponse(resourceAcl, containerLinks, emptyList(), "<" + resourceAcl + "> <" + RDF_TYPE + "> <" +
                 RDF_SOURCE + "> .");
 
-        reconfigureExporter();
-
         exporter.run();
 
         assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
@@ -403,7 +391,7 @@ public class ExportStreamTest extends ExportTestBase {
 
         final URI resourceAcl = URI.create(resource.toString() + "/fcr:acl");
         final URI resource2 = URI.create(resource.toString() + "/2");
-        final URI resource3 = URI.create(resource2.toString() + "/fcr%3Ametadata");
+        final URI resource3 = URI.create(resource2 + "/fcr%3Ametadata");
 
         mockResponse(resource, containerLinks, new ArrayList<>(), resourceAcl,"<" + resource
                         + "> <" + RDF_TYPE + "> <" + REPOSITORY_NAMESPACE + "RepositoryRoot> .\n"
@@ -414,8 +402,6 @@ public class ExportStreamTest extends ExportTestBase {
         mockResponse(resource2, binaryLinks, singletonList(resource3), "binary");
         mockResponse(resource3, containerLinks, emptyList(), "<" + resource3 + "> <" + RDF_TYPE + "> <" +
                 RDF_SOURCE + "> .");
-
-        reconfigureExporter();
 
         exporter.run();
 
@@ -432,8 +418,6 @@ public class ExportStreamTest extends ExportTestBase {
         config.setIncludeBinaries(true);
         config.setResource(resource);
 
-        reconfigureExporter();
-
         ResponseMocker.mockHeadResponseError(client, resource, 401);
 
         assertThrows(AuthenticationRequiredRuntimeException.class, () -> exporter.run());
@@ -442,8 +426,6 @@ public class ExportStreamTest extends ExportTestBase {
     @Test
     public void testMetadataOnlyDoesNotExportBinaries() throws Exception {
         config.setResource(resource);
-
-        reconfigureExporter();
 
         exporter.run();
 
@@ -454,8 +436,6 @@ public class ExportStreamTest extends ExportTestBase {
     @Test
     public void testMetadataOnlyExportsContainers() throws Exception {
         config.setResource(resource);
-
-        reconfigureExporter();
 
         exporter.run();
         assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
@@ -469,7 +449,6 @@ public class ExportStreamTest extends ExportTestBase {
         mockResponse(resource6, containerLinks, emptyList(), "<" + resource6 + "> <" + RDF_TYPE + "> <" + RDF_SOURCE + "> .");
         config.setResource(resource);
 
-        reconfigureExporter();
         exporter.run();
         assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + ".nt"));
         assertTrue(handler.wroteFile(exportDirectory + "/rest/" + id + "/2.nt"));

--- a/src/test/java/org/fcrepo/importexport/exporter/ExportTestBase.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExportTestBase.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.importexport.exporter;
+
+import org.apache.commons.io.FileUtils;
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.importexport.test.util.ResponseMocker;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINER;
+import static org.fcrepo.importexport.common.FcrepoConstants.CONTAINS;
+import static org.fcrepo.importexport.common.FcrepoConstants.NON_RDF_SOURCE;
+import static org.fcrepo.importexport.common.FcrepoConstants.RDF_SOURCE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExportTestBase {
+
+    // Fcrepo client and builder
+    protected FcrepoClient client;
+    protected FcrepoClient.FcrepoClientBuilder clientBuilder;
+
+    // URI of the repository root
+    protected URI rootResource;
+    // URI of the resource to be exported
+    protected URI resource;
+
+    // Directory to export to
+    protected String exportDirectory;
+
+    // Links for different types of resources
+    protected List<URI> binaryLinks = Arrays.asList(new URI(NON_RDF_SOURCE.getURI()));
+    protected List<URI> containerLinks = Arrays.asList(new URI(CONTAINER.getURI()));
+    protected List<URI> descriptionLinks = new ArrayList<>();
+    protected List<URI> describedbyLinks = new ArrayList<>();
+    protected String[] predicates = new String[]{ CONTAINS.toString() };
+
+    protected List<File> tearDownFiles = new ArrayList<>();
+
+    public ExportTestBase() throws URISyntaxException {
+        // Needed to allow for the URISyntaxException thrown by new URI() above
+    }
+
+    @Before
+    public void setUp() throws Exception{
+        client = mock(FcrepoClient.class);
+        clientBuilder = mock(FcrepoClient.FcrepoClientBuilder.class);
+        when(clientBuilder.build()).thenReturn(client);
+        rootResource = new URI("http://localhost:8080/rest");
+        descriptionLinks.add(new URI(RDF_SOURCE.getURI()));
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            if (!tearDownFiles.isEmpty()) {
+                for (File file : tearDownFiles) {
+                    FileUtils.forceDelete(file);
+                }
+                tearDownFiles.clear();
+            }
+            FileUtils.deleteDirectory(new File(exportDirectory));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Mocks a response for a resource
+     *
+     * @param uri URI of the resource
+     * @param typeLinks Link headers with rel="type" for the resource
+     * @param describedbyLinks Link headers with rel="describedby" for the resource
+     * @param body body of the response
+     * @throws FcrepoOperationFailedException client failures
+     */
+    protected void mockResponse(final URI uri, final List<URI> typeLinks, final List<URI> describedbyLinks,
+                              final String body) throws FcrepoOperationFailedException {
+        mockResponse(uri, typeLinks, describedbyLinks, null, body, null);
+    }
+
+    /**
+     * Mocks a response for a resource
+     *
+     * @param uri URI of the resource
+     * @param typeLinks Link headers with rel="type" for the resource
+     * @param describedbyLinks Link headers with rel="describedby" for the resource
+     * @param aclLink Link headers with rel="acl" for the resource
+     * @param body body of the response
+     * @param contentType content type of the response
+     * @throws FcrepoOperationFailedException client failures
+     */
+    protected void mockResponse(final URI uri, final List<URI> typeLinks, final List<URI> describedbyLinks,
+                              final URI aclLink, final String body, final String contentType) throws FcrepoOperationFailedException {
+        ResponseMocker.mockHeadResponse(client, uri, typeLinks, describedbyLinks, null, aclLink, contentType);
+        ResponseMocker.mockGetResponse(client, uri, typeLinks, describedbyLinks,  null, aclLink, body, contentType);
+    }
+
+}

--- a/src/test/java/org/fcrepo/importexport/exporter/ExportVersionsTest.java
+++ b/src/test/java/org/fcrepo/importexport/exporter/ExportVersionsTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.io.IOException;
@@ -108,7 +108,7 @@ public class ExportVersionsTest {
 
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
+        openMocks(this);
 
         when(clientBuilder.build()).thenReturn(client);
 

--- a/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/AbstractResourceIT.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 import java.util.Map;
@@ -37,6 +36,7 @@ import org.fcrepo.client.PutBuilder;
 import org.junit.Before;
 import org.slf4j.Logger;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.http.HttpStatus.SC_GONE;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.jena.rdf.model.ResourceFactory.createPlainLiteral;
@@ -176,7 +176,7 @@ public abstract class AbstractResourceIT {
                 uri, response.getStatusCode(), response.getHeaderValue("Location"));
 
         try {
-            logger().debug("body = {}", IOUtils.toString(response.getBody(), "UTF-8"));
+            logger().debug("body = {}", IOUtils.toString(response.getBody(), UTF_8));
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
@@ -195,13 +195,8 @@ public abstract class AbstractResourceIT {
     }
 
     protected InputStream insertTitle(final String title) {
-        try {
-            return new ByteArrayInputStream(("INSERT DATA { <> <" + DC_TITLE + "> '" + title + "' . }")
-                    .getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            // can't actually happen
-            throw new RuntimeException(e);
-        }
+        return new ByteArrayInputStream(("INSERT DATA { <> <" + DC_TITLE + "> '" + title + "' . }")
+            .getBytes(UTF_8));
     }
 
     protected FcrepoResponse patch(final URI uri, final String command) throws FcrepoOperationFailedException {
@@ -221,7 +216,7 @@ public abstract class AbstractResourceIT {
 
     protected String getAsString(final URI uri) throws FcrepoOperationFailedException, IOException {
         final FcrepoResponse response = clientBuilder.build().get(uri).perform();
-        return IOUtils.toString(response.getBody());
+        return IOUtils.toString(response.getBody(), UTF_8);
     }
 
     protected void assertHasTitle(final URI uri, final String title) throws FcrepoOperationFailedException {

--- a/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
+++ b/src/test/java/org/fcrepo/importexport/integration/ExporterIT.java
@@ -97,6 +97,30 @@ public class ExporterIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testExportStreaming() throws Exception {
+        // Create a repository resource
+        final FcrepoResponse response = create(url);
+        assertEquals(SC_CREATED, response.getStatusCode());
+        assertEquals(url, response.getLocation());
+
+        // Run an export process
+        final Config config = new Config();
+        config.setMode("export");
+        config.setBaseDirectory(TARGET_DIR);
+        config.setResource(url);
+        config.setUsername(USERNAME);
+        config.setPassword(PASSWORD);
+        config.setPredicates(new String[]{ CONTAINS.toString() });
+        config.setStreaming(true);
+
+        final Exporter exporter = new Exporter(config, clientBuilder);
+        exporter.run();
+
+        // Verify
+        assertTrue(new File(TARGET_DIR, url.getPath() + DEFAULT_RDF_EXT).exists());
+    }
+
+    @Test
     public void testExportBogusResource() throws Exception {
         final Config config = new Config();
         config.setMode("export");

--- a/src/test/java/org/fcrepo/importexport/test/util/ResponseMocker.java
+++ b/src/test/java/org/fcrepo/importexport/test/util/ResponseMocker.java
@@ -46,7 +46,7 @@ public abstract class ResponseMocker {
 
     /**
      * Mocks a successful HEAD request response
-     * 
+     *
      * @param client client
      * @param uri uri of destination being mocked
      * @param typeLinks type links
@@ -56,6 +56,24 @@ public abstract class ResponseMocker {
      */
     public static void mockHeadResponse(final FcrepoClient client, final URI uri, final List<URI> typeLinks,
                                         final List<URI> describedbyLinks, final URI timemapLink, final URI aclLink)
+            throws FcrepoOperationFailedException {
+        mockHeadResponse(client, uri, typeLinks, describedbyLinks, timemapLink, aclLink, null);
+    }
+
+    /**
+     * Mocks a successful HEAD request response
+     *
+     * @param client client
+     * @param uri uri of destination being mocked
+     * @param typeLinks type links
+     * @param describedbyLinks described by links
+     * @param timemapLink timemap links
+     * @param contentType content type of response
+     * @throws FcrepoOperationFailedException client failures
+     */
+    public static void mockHeadResponse(final FcrepoClient client, final URI uri, final List<URI> typeLinks,
+                                        final List<URI> describedbyLinks, final URI timemapLink, final URI aclLink,
+                                        final String contentType)
             throws FcrepoOperationFailedException {
         final HeadBuilder headBuilder = mock(HeadBuilder.class);
         final FcrepoResponse headResponse = mock(FcrepoResponse.class);
@@ -73,6 +91,25 @@ public abstract class ResponseMocker {
         if (aclLink != null) {
             when(headResponse.getLinkHeaders(eq("acl"))).thenReturn(Arrays.asList(aclLink));
         }
+        if (contentType != null) {
+            when(headResponse.getContentType()).thenReturn(contentType);
+        }
+    }
+
+    /**
+     * Mocks a successful GET request response
+     *
+     * @param client client
+     * @param uri uri of destination being mocked
+     * @param typeLinks type links
+     * @param describedbyLinks described by links
+     * @param body body of response
+     * @throws FcrepoOperationFailedException client failures
+     */
+    public static void mockGetResponse(final FcrepoClient client, final URI uri, final List<URI> typeLinks,
+                                       final List<URI> describedbyLinks, final URI timemapLink, final URI aclLink,
+                                       final String body) throws FcrepoOperationFailedException {
+        mockGetResponse(client, uri, typeLinks, describedbyLinks, timemapLink, aclLink, body, null);
     }
 
     /**
@@ -83,11 +120,12 @@ public abstract class ResponseMocker {
      * @param typeLinks type links
      * @param describedbyLinks described by links
      * @param body body of response
+     * @param contentType content type of response
      * @throws FcrepoOperationFailedException client failures
      */
     public static void mockGetResponse(final FcrepoClient client, final URI uri, final List<URI> typeLinks,
                                        final List<URI> describedbyLinks, final URI timemapLink, final URI aclLink,
-                                       final String body)
+                                       final String body, final String contentType)
         throws FcrepoOperationFailedException {
         final GetBuilder getBuilder = mock(GetBuilder.class);
         final FcrepoResponse getResponse = mock(FcrepoResponse.class);
@@ -111,6 +149,10 @@ public abstract class ResponseMocker {
 
         if (aclLink != null) {
             when(getResponse.getLinkHeaders(eq("acl"))).thenReturn(Arrays.asList(aclLink));
+        }
+
+        if (contentType != null) {
+            when(getResponse.getContentType()).thenReturn(contentType);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3968

# What does this Pull Request do?
Adds a `--streaming` option which works for exporting to handle the body of a resource as a stream instead of collecting it into a model. This allows handling repositories with large flat structures more efficiently but requires the output to be `application/n-triples` 

# How should this be tested?

Output should be the same but for large repositories with lots of children under the root this should perform better.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo-exts/committers

